### PR TITLE
Fix/osx decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## Version 0.2
+
+- Fix major bug in decoding output on osx. Now handles both regular and "special" (non-ascii) utf8 chars appropriately.
+- add simple tests for the fix!
+- add changelog.
+
+## Version 0.1
+
+- linux implementation using secret-service backend.
+- osx implementation using security cli.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 authors = ["Walther Chen <walther.chen@gmail.com>"]
 description = "Cross-platform library for managing passwords"
 homepage = "https://github.com/hwchen/keyring-rs.git"
-keywords = ["password", "linux", "keychain", "keyring"]
+keywords = ["password", "linux", "osx", "keychain", "keyring"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies]
 advapi32-sys = "0.2.0"


### PR DESCRIPTION
Fix for bug in osx password decoding.

It turns out that the security cli `security find-generic-password` command with `-w` (password only output) does not output only a hex representation. So the previous strategy of always trying to interpret the output as hex was incorrect (not sure why my manual testing didn't catch it before? ugh).

Anyways, the solution is to parse the output from the `-g` flag, which has `""` surrounding a "normal" password output, and no `""` if the output is in hex format. (The hex format is used for "special" utf8 chars, which appears to be anything not in the ascii range).

bumps version to 0.2

Closes #2 and #4
Usurps  and closes #3 