### PR TITLE
Add Mac keychain support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = "2.0.5"
 rpassword = "0.1.3"
 rustc-serialize = "0.3.18"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 secret-service = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ secret-service = "0.3.0"
 [target.'cfg(windows)'.dependencies]
 advapi32-sys = "0.2.0"
 winapi = "0.2.5"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = { version = "*", git = "https://github.com/infincia/rust-security-framework.git", branch = "add-password-support" }
+#security-framework = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustc-serialize = "0.3.18"
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = "0.3.0"
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 advapi32-sys = "0.2.0"
 winapi = "0.2.5"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 #[cfg(target_os = "linux")]
 use secret_service::SsError;
+#[cfg(target_os = "macos")]
+use security_framework::base::Error as SfError;
 use std::error;
 use std::fmt;
 use std::string::FromUtf8Error;
@@ -64,6 +66,13 @@ impl error::Error for KeyringError {
 impl From<SsError> for KeyringError {
     fn from(err: SsError) -> KeyringError {
         KeyringError::SecretServiceError(err)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl From<SfError> for KeyringError {
+    fn from(err: SfError) -> KeyringError {
+        KeyringError::MacOsKeychainError(err)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub type Result<T> = ::std::result::Result<T, KeyringError>;
 #[derive(Debug)]
 pub enum KeyringError {
     #[cfg(target_os = "macos")]
-    MacOsKeychainError,
+    MacOsKeychainError(SfError),
     #[cfg(target_os = "linux")]
     SecretServiceError(SsError),
     #[cfg(target_os = "windows")]
@@ -26,7 +26,7 @@ impl fmt::Display for KeyringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             #[cfg(target_os = "macos")]
-            KeyringError::MacOsKeychainError => write!(f, "Mac Os Keychain Error"),
+            KeyringError::MacOsKeychainError(ref err) => write!(f, "Mac Os Keychain Error: {}", err),
             #[cfg(target_os = "linux")]
             KeyringError::SecretServiceError(ref err) => write!(f, "Secret Service Error: {}", err),
             #[cfg(target_os = "windows")]
@@ -42,7 +42,7 @@ impl error::Error for KeyringError {
     fn description(&self) -> &str {
         match *self {
             #[cfg(target_os = "macos")]
-            KeyringError::MacOsKeychainError => "Mac Os Keychain Error",
+            KeyringError::MacOsKeychainError(ref err) => err.description(),
             #[cfg(target_os = "linux")]
             KeyringError::SecretServiceError(ref err) => err.description(),
             #[cfg(target_os = "windows")]
@@ -57,6 +57,8 @@ impl error::Error for KeyringError {
         match *self {
             #[cfg(target_os = "linux")]
             KeyringError::SecretServiceError(ref err) => Some(err),
+            #[cfg(target_os = "macos")]
+            KeyringError::MacOsKeychainError(ref err) => Some(err),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub use windows::Keyring;
 #[cfg(target_os = "macos")]
 extern crate rustc_serialize;
 #[cfg(target_os = "macos")]
+extern crate security_framework;
+#[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]
 pub use macos::Keyring;

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -44,14 +44,6 @@ impl<'a> Keyring<'a> {
     }
 }
 
-fn is_not_hex_output(s: &str) -> bool {
-    assert!(s.len() >= 11);
-    const MATCH_START: &'static str = "password: \"";
-    const MATCH_END: char = '\"';
-
-    s.starts_with(MATCH_START) && s.ends_with(MATCH_END)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -56,30 +56,51 @@ fn is_not_hex_output(s: &str) -> bool {
 mod test {
     use super::*;
 
-    #[test]
-    fn test_password_output_is_not_hex() {
-        let output_1 = r#"password: "0xE5A4A7E6A0B9""#;
-        let output_2 = r#"password: 0xE5A4A7E6A0B9"#;
+    static TEST_SERVICE: &'static str = "test.keychain-rs.io";
+    static TEST_USER: &'static str = "user@keychain-rs.io";
+    static TEST_ASCII_PASSWORD: &'static str = "my_password";
+    static TEST_NON_ASCII_PASSWORD: &'static str = "大根";
 
-        assert_eq!(is_not_hex_output(output_1), true);
-        assert_eq!(is_not_hex_output(output_2), false);
+    #[test]
+    fn test_add_ascii_password() {
+        let keyring = Keyring::new(TEST_SERVICE, TEST_USER);
+
+        keyring.set_password(TEST_ASCII_PASSWORD).unwrap();
+
+        keyring.delete_password().unwrap();
     }
 
     #[test]
-    fn test_special_char_passwords() {
-        // need to worry about unlocking keychain?
+    fn test_round_trip_ascii_password() {
+        let keyring = Keyring::new(TEST_SERVICE, TEST_USER);
 
-        let password_1 = "大根";
-        let password_2 = "0xE5A4A7E6A0B9"; // Above in hex string
+        keyring.set_password(TEST_ASCII_PASSWORD).unwrap();
 
-        let keyring = Keyring::new("testuser", "testservice");
-        keyring.set_password(password_1).unwrap();
-        let res_1 = keyring.get_password().unwrap();
-        assert_eq!(res_1, password_1);
+        let stored_password = keyring.get_password().unwrap();
 
-        keyring.set_password(password_2).unwrap();
-        let res_2 = keyring.get_password().unwrap();
-        assert_eq!(res_2, password_2);
+        assert_eq!(stored_password, TEST_ASCII_PASSWORD);
+
+        keyring.delete_password().unwrap();
+    }
+
+    #[test]
+    fn test_add_non_ascii_password() {
+        let keyring = Keyring::new(TEST_SERVICE, TEST_USER);
+
+        keyring.set_password(TEST_NON_ASCII_PASSWORD).unwrap();
+
+        keyring.delete_password().unwrap();
+    }
+
+    #[test]
+    fn test_round_trip_non_ascii_password() {
+        let keyring = Keyring::new(TEST_SERVICE, TEST_USER);
+
+        keyring.set_password(TEST_NON_ASCII_PASSWORD).unwrap();
+
+        let stored_password = keyring.get_password().unwrap();
+
+        assert_eq!(stored_password, TEST_NON_ASCII_PASSWORD);
 
         keyring.delete_password().unwrap();
     }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,7 +1,3 @@
-use ::KeyringError;
-use std::io::Write;
-use std::process::{Command, Stdio};
-use rustc_serialize::hex::FromHex;
 use security_framework::os::macos::passwords::{find_generic_password, set_generic_password, delete_generic_password};
 
 pub struct Keyring<'a> {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -38,24 +38,9 @@ impl<'a> Keyring<'a> {
     }
 
     pub fn delete_password(&self) -> ::Result<()> {
-        let output = Command::new("security")
-            .arg("delete-generic-password")
-            .arg("-a")
-            .arg(self.username)
-            .arg("-s")
-            .arg(self.service)
-            .output();
+        try!(delete_generic_password(None, self.service, self.username));
 
-        match output {
-            Ok(output) => {
-                if output.status.success() {
-                    Ok(())
-                } else {
-                    Err(KeyringError::MacOsKeychainError)
-                }
-            },
-            _ => Err(KeyringError::MacOsKeychainError)
-        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I've added support for using the Mac keychain directly, using the security-framework crate.

**Note**: this PR should not be merged until the upstream security-framework crate merges a [PR to add password support](https://github.com/sfackler/rust-security-framework/pull/17). 

For testing purposes I have pointed this PR to a fork of security-framework, but once they merge that password support PR, I'll push another commit here to switch the cargo config back to using the upstream crate directly.

When running the included tests, be sure to disable parallel tests like this:

```
RUST_TEST_THREADS=1 cargo test
```

If the tests are run in parallel, the assert_eq!() call in the 2 round trip tests will usually fail, as the other tests might have changed the password already.