### PR TITLE
Replace unwrap()s by '?'

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -27,7 +27,7 @@ impl<'a> Keyring<'a> {
     pub fn set_password(&self, password: &str) -> ::Result<()> {
         let ss = try!(SecretService::new(EncryptionType::Dh));
         let collection = try!(ss.get_default_collection());
-        if collection.is_locked().unwrap() {
+        if collection.is_locked()? {
             try!(collection.unlock());
         }
         let label = &format!("Password for {} on {}", self.username, self.service)[..];
@@ -44,7 +44,7 @@ impl<'a> Keyring<'a> {
     pub fn get_password(&self) -> ::Result<String> {
         let ss = try!(SecretService::new(EncryptionType::Dh));
         let collection = try!(ss.get_default_collection());
-        if collection.is_locked().unwrap() {
+        if collection.is_locked()? {
             try!(collection.unlock());
         }
         let search = try!(collection.search_items(self.attributes.clone()));
@@ -57,7 +57,7 @@ impl<'a> Keyring<'a> {
     pub fn delete_password(&self) -> ::Result<()> {
         let ss = try!(SecretService::new(EncryptionType::Dh));
         let collection = try!(ss.get_default_collection());
-        if collection.is_locked().unwrap() {
+        if collection.is_locked()? {
             try!(collection.unlock());
         }
         let search = try!(collection.search_items(self.attributes.clone()));


### PR DESCRIPTION
These unwrap()s lead to panic on the
real linux machine, but I don't know
what is cause of dbus error.