### PR TITLE
Linux: Only include application name on create

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -13,7 +13,6 @@ impl<'a> Keyring<'a> {
 
     pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
         let attributes = vec![
-            ("application", "rust-keyring"),
             ("service", service),
             ("username", username),
         ];
@@ -30,10 +29,12 @@ impl<'a> Keyring<'a> {
         if collection.is_locked()? {
             try!(collection.unlock());
         }
+        let mut attrs = self.attributes.clone();
+        attrs.push(("application", "rust-keyring"));
         let label = &format!("Password for {} on {}", self.username, self.service)[..];
         try!(collection.create_item(
             label,
-            self.attributes.clone(),
+            attrs,
             password.as_bytes(),
             true, // replace
             "text/plain",


### PR DESCRIPTION
PR Note:
I make use of an application in python that utilizes the keyring library, which works fine cross Linux and Mac, as it only attempts to set the service and username, while I also use this rust integration which currently forces the "rust-keyring" application during all operations, including search.  This forceful injection of the application into the query parameters mean it will only ever return results that were created by this application, and severely limits the query operation (making it un-usable in my own cases).  This  Small PR corrects that by only including application when it's really needed (on create)

Should this be merged,  could you please bump a micro version to allow us to update in-band? ie: "0.7.1"


Commit Message Below:

Currently the get_password method is doing a strict search including the
application name that was sent in during the Struct initialiation.  This
means that attempting to query for any password that was not previously
created by this app specifically will fail.

We adjust this to only create the application field on creation, and
leave searching to just look for service and username.

This brings "better" parity to the python and rust clients, as well as
parity within the MacOS and Linux libraries.