### PR TITLE
Removes/upgrades outdated depndencies, fixes clippy lints and upgrades to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ description = "Cross-platform library for managing passwords"
 homepage = "https://github.com/hwchen/keyring-rs.git"
 keywords = ["password", "cross-platform", "keychain", "keyring"]
 license = "MIT OR Apache-2.0"
-build = "build.rs"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
 version = "0.7.1"
@@ -23,7 +22,3 @@ winapi = "0.2.5"
 [dev-dependencies]
 clap = "2.0.5"
 rpassword = "2.0.0"
-skeptic = "0.13"
-
-[build-dependencies]
-skeptic = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
 version = "0.7.1"
+edition = "2018"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ secret-service = "1.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2.1"
-advapi32-sys = "0.2.0"
-winapi = "0.2.5"
+winapi = { version =  "0.3", features = ["wincred", "minwindef"] }
 
 [dev-dependencies]
 clap = "2.0.5"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-extern crate skeptic;
-
-fn main() {
-    // generate doc tests for `README.md`
-    // (I set them all to no_run, to just check for compilation)
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -2,7 +2,7 @@ extern crate clap;
 extern crate keyring;
 extern crate rpassword;
 
-use clap::{Arg, App, SubCommand};
+use clap::{App, Arg, SubCommand};
 use keyring::Keyring;
 use rpassword::read_password;
 
@@ -13,32 +13,42 @@ fn main() -> Result<(), Box<Error>> {
         .version(env!("CARGO_PKG_VERSION"))
         .author("Walther Chen <walther.chen@gmail.com>")
         .about("Cross-platform utility to get and set passwords from system vault")
-        .subcommand(SubCommand::with_name("set")
-            .about("For username, set password")
-            .arg(Arg::with_name("username")
-                 .help("Username")
-                 .required(true)
-                 .index(1)))
-        .subcommand(SubCommand::with_name("get")
-            .about("For username, get password")
-            .arg(Arg::with_name("username")
-                 .help("Username")
-                 .required(true)
-                 .index(1)))
-        .subcommand(SubCommand::with_name("delete")
-            .about("For username, delete password")
-            .arg(Arg::with_name("username")
-                 .help("Username")
-                 .required(true)
-                 .index(1)))
+        .subcommand(
+            SubCommand::with_name("set")
+                .about("For username, set password")
+                .arg(
+                    Arg::with_name("username")
+                        .help("Username")
+                        .required(true)
+                        .index(1),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("get")
+                .about("For username, get password")
+                .arg(
+                    Arg::with_name("username")
+                        .help("Username")
+                        .required(true)
+                        .index(1),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("delete")
+                .about("For username, delete password")
+                .arg(
+                    Arg::with_name("username")
+                        .help("Username")
+                        .required(true)
+                        .index(1),
+                ),
+        )
         .get_matches();
 
     let service = "keyring-rs";
 
     if let Some(set) = matches.subcommand_matches("set") {
-        let username = set
-            .value_of("username")
-            .ok_or("No username found to set")?;
+        let username = set.value_of("username").ok_or("No username found to set")?;
         let keyring = Keyring::new(service, username);
 
         println!("Enter Password");
@@ -52,9 +62,7 @@ fn main() -> Result<(), Box<Error>> {
     }
 
     if let Some(get) = matches.subcommand_matches("get") {
-        let username = get
-           .value_of("username")
-           .ok_or("No username found to get")?;
+        let username = get.value_of("username").ok_or("No username found to get")?;
         let keyring = Keyring::new(service, username);
 
         match keyring.get_password() {
@@ -77,4 +85,3 @@ fn main() -> Result<(), Box<Error>> {
 
     Ok(())
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@ use std::error;
 use std::fmt;
 use std::string::FromUtf8Error;
 
-
 pub type Result<T> = ::std::result::Result<T, KeyringError>;
 
 #[derive(Debug)]
@@ -26,7 +25,9 @@ impl fmt::Display for KeyringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             #[cfg(target_os = "macos")]
-            KeyringError::MacOsKeychainError(ref err) => write!(f, "Mac Os Keychain Error: {}", err),
+            KeyringError::MacOsKeychainError(ref err) => {
+                write!(f, "Mac Os Keychain Error: {}", err)
+            }
             #[cfg(target_os = "linux")]
             KeyringError::SecretServiceError(ref err) => write!(f, "Secret Service Error: {}", err),
             #[cfg(target_os = "windows")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,7 @@ impl error::Error for KeyringError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             #[cfg(target_os = "linux")]
             KeyringError::SecretServiceError(ref err) => Some(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,6 @@ extern crate byteorder;
 #[cfg(target_os = "windows")]
 extern crate winapi;
 #[cfg(target_os = "windows")]
-extern crate advapi32;
-#[cfg(target_os = "windows")]
 mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::Keyring;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,25 +4,17 @@
 
 // Configure for Linux
 #[cfg(target_os = "linux")]
-extern crate secret_service;
-#[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::Keyring;
 
 // Configure for Windows
 #[cfg(target_os = "windows")]
-extern crate byteorder;
-#[cfg(target_os = "windows")]
-extern crate winapi;
-#[cfg(target_os = "windows")]
 mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::Keyring;
 
 // Configure for OSX
-#[cfg(target_os = "macos")]
-extern crate security_framework;
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,6 +1,5 @@
+use crate::error::{KeyringError, Result};
 use secret_service::{EncryptionType, SecretService};
-
-use KeyringError;
 
 pub struct Keyring<'a> {
     attributes: Vec<(&'a str, &'a str)>,
@@ -13,52 +12,52 @@ impl<'a> Keyring<'a> {
     pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
         let attributes = vec![("service", service), ("username", username)];
         Keyring {
-            attributes: attributes,
-            service: service,
-            username: username,
+            attributes,
+            service,
+            username,
         }
     }
 
-    pub fn set_password(&self, password: &str) -> ::Result<()> {
-        let ss = try!(SecretService::new(EncryptionType::Dh));
-        let collection = try!(ss.get_default_collection());
+    pub fn set_password(&self, password: &str) -> Result<()> {
+        let ss = SecretService::new(EncryptionType::Dh)?;
+        let collection = ss.get_default_collection()?;
         if collection.is_locked()? {
-            try!(collection.unlock());
+            collection.unlock()?;
         }
         let mut attrs = self.attributes.clone();
         attrs.push(("application", "rust-keyring"));
         let label = &format!("Password for {} on {}", self.username, self.service)[..];
-        try!(collection.create_item(
+        collection.create_item(
             label,
             attrs,
             password.as_bytes(),
             true, // replace
             "text/plain",
-        ));
+        )?;
         Ok(())
     }
 
-    pub fn get_password(&self) -> ::Result<String> {
-        let ss = try!(SecretService::new(EncryptionType::Dh));
-        let collection = try!(ss.get_default_collection());
+    pub fn get_password(&self) -> Result<String> {
+        let ss = SecretService::new(EncryptionType::Dh)?;
+        let collection = ss.get_default_collection()?;
         if collection.is_locked()? {
-            try!(collection.unlock());
+            collection.unlock()?;
         }
-        let search = try!(collection.search_items(self.attributes.clone()));
-        let item = try!(search.get(0).ok_or(KeyringError::NoPasswordFound));
-        let secret_bytes = try!(item.get_secret());
-        let secret = try!(String::from_utf8(secret_bytes));
+        let search = collection.search_items(self.attributes.clone())?;
+        let item = search.get(0).ok_or(KeyringError::NoPasswordFound)?;
+        let secret_bytes = item.get_secret()?;
+        let secret = String::from_utf8(secret_bytes)?;
         Ok(secret)
     }
 
-    pub fn delete_password(&self) -> ::Result<()> {
-        let ss = try!(SecretService::new(EncryptionType::Dh));
-        let collection = try!(ss.get_default_collection());
+    pub fn delete_password(&self) -> Result<()> {
+        let ss = SecretService::new(EncryptionType::Dh)?;
+        let collection = ss.get_default_collection()?;
         if collection.is_locked()? {
-            try!(collection.unlock());
+            collection.unlock()?;
         }
-        let search = try!(collection.search_items(self.attributes.clone()));
-        let item = try!(search.get(0).ok_or(KeyringError::NoPasswordFound));
-        Ok(try!(item.delete()))
+        let search = collection.search_items(self.attributes.clone())?;
+        let item = search.get(0).ok_or(KeyringError::NoPasswordFound)?;
+        Ok(item.delete()?)
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,6 +1,6 @@
 use secret_service::{EncryptionType, SecretService};
 
-use ::KeyringError;
+use KeyringError;
 
 pub struct Keyring<'a> {
     attributes: Vec<(&'a str, &'a str)>,
@@ -10,12 +10,8 @@ pub struct Keyring<'a> {
 
 // Eventually try to get collection into the Keyring struct?
 impl<'a> Keyring<'a> {
-
     pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
-        let attributes = vec![
-            ("service", service),
-            ("username", username),
-        ];
+        let attributes = vec![("service", service), ("username", username)];
         Keyring {
             attributes: attributes,
             service: service,
@@ -66,4 +62,3 @@ impl<'a> Keyring<'a> {
         Ok(try!(item.delete()))
     }
 }
-

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,5 +1,5 @@
-use security_framework::os::macos::passwords::find_generic_password;
 use security_framework::os::macos::keychain::SecKeychain;
+use security_framework::os::macos::passwords::find_generic_password;
 
 pub struct Keyring<'a> {
     service: &'a str,
@@ -8,7 +8,6 @@ pub struct Keyring<'a> {
 
 // Eventually try to get collection into the Keyring struct?
 impl<'a> Keyring<'a> {
-
     pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
         Keyring {
             service: service,
@@ -17,8 +16,11 @@ impl<'a> Keyring<'a> {
     }
 
     pub fn set_password(&self, password: &str) -> ::Result<()> {
-        SecKeychain::default()?
-            .set_generic_password(self.service, self.username, password.as_bytes())?;
+        SecKeychain::default()?.set_generic_password(
+            self.service,
+            self.username,
+            password.as_bytes(),
+        )?;
 
         Ok(())
     }
@@ -43,4 +45,3 @@ impl<'a> Keyring<'a> {
         Ok(())
     }
 }
-

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,3 +1,4 @@
+use crate::error::Result;
 use security_framework::os::macos::keychain::SecKeychain;
 use security_framework::os::macos::passwords::find_generic_password;
 
@@ -9,13 +10,10 @@ pub struct Keyring<'a> {
 // Eventually try to get collection into the Keyring struct?
 impl<'a> Keyring<'a> {
     pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
-        Keyring {
-            service: service,
-            username: username,
-        }
+        Keyring { service, username }
     }
 
-    pub fn set_password(&self, password: &str) -> ::Result<()> {
+    pub fn set_password(&self, password: &str) -> Result<()> {
         SecKeychain::default()?.set_generic_password(
             self.service,
             self.username,
@@ -25,19 +23,19 @@ impl<'a> Keyring<'a> {
         Ok(())
     }
 
-    pub fn get_password(&self) -> ::Result<String> {
+    pub fn get_password(&self) -> Result<String> {
         let (password_bytes, _) = find_generic_password(None, self.service, self.username)?;
 
         // Mac keychain allows non-UTF8 values, but this library only supports adding UTF8 items
         // to the keychain, so this should only fail if we are trying to retrieve a non-UTF8
         // password that was added to the keychain by another library
 
-        let password = try!(String::from_utf8(password_bytes.to_vec()));
+        let password = String::from_utf8(password_bytes.to_vec())?;
 
         Ok(password)
     }
 
-    pub fn delete_password(&self) -> ::Result<()> {
+    pub fn delete_password(&self) -> Result<()> {
         let (_, item) = find_generic_password(None, self.service, self.username)?;
 
         item.delete();

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,8 +1,8 @@
+use crate::error::{KeyringError, Result};
 use byteorder::{ByteOrder, LittleEndian};
 use std::ffi::OsStr;
 use std::iter::once;
 use std::mem;
-use std::os::raw::c_void;
 use std::os::windows::ffi::OsStrExt;
 use std::slice;
 use std::str;
@@ -11,7 +11,6 @@ use winapi::um::wincred::{
     CredDeleteW, CredFree, CredReadW, CredWriteW, CREDENTIALW, CRED_PERSIST_ENTERPRISE,
     CRED_TYPE_GENERIC, PCREDENTIALW, PCREDENTIAL_ATTRIBUTEW,
 };
-use KeyringError;
 
 // DWORD is u32
 // LPCWSTR is *const u16
@@ -29,13 +28,10 @@ pub struct Keyring<'a> {
 
 impl<'a> Keyring<'a> {
     pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
-        Keyring {
-            service: service,
-            username: username,
-        }
+        Keyring { service, username }
     }
 
-    pub fn set_password(&self, password: &str) -> ::Result<()> {
+    pub fn set_password(&self, password: &str) -> Result<()> {
         // Setting values of credential
 
         let flags = 0;
@@ -92,7 +88,7 @@ impl<'a> Keyring<'a> {
         }
     }
 
-    pub fn get_password(&self) -> ::Result<String> {
+    pub fn get_password(&self) -> Result<String> {
         // passing uninitialized pcredential.
         // Should be ok; it's freed by a windows api
         // call CredFree.
@@ -139,7 +135,7 @@ impl<'a> Keyring<'a> {
         }
     }
 
-    pub fn delete_password(&self) -> ::Result<()> {
+    pub fn delete_password(&self) -> Result<()> {
         let target_name: String = [self.username, self.service].join(".");
 
         let cred_type = CRED_TYPE_GENERIC;

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This is an opinionated PR, feedback is welcome

* Removes skeptic dep, as it does not seem to be used and it had a couple of outdated dependencies.
* Upgrade to winapi 0.3 and removes `advapi32-sys` from windows.
* Fixes all the clippy lints on windows and linux.
* Upgrades to edition 2018
* Formats everything to 1.40
* Removes mem::uninitialized from windows