### PR TITLE
Update secret-service to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 security-framework = "0.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-secret-service = "1.0.0"
+secret-service = "1.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2.1"


### PR DESCRIPTION
This resolves an issue with macOS's keychain/Windows Vault not returning a proper `NoPasswordFound` error if an item doesn't exist.