### PR TITLE
notes on cleaning up error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,64 @@
+// TODO real error handling
+// Better unify errors so I don't have os-specific errors for important ones
+// like no password found.
+// Less important ones can get a description and put into Other
+//
+// Consider using thiserror
+//
+// ```
+// pub enum KeyringError {
+//     NoBackendFound,
+//     NoLogonSession, // windows has this, do linux and macos?
+//     NoPasswordcFound,
+//     Parse(FromUtf8Error),
+//     Other(String), // use this for things like windows ERROR_INVALID_FLAGS
+// }
+// ```
+//
+// ## Possible errors:
+//
+// Windows:
+// Call GetLastError in order to get error code to match.
+//
+// https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-creddeletew
+// - ERROR_NOT_FOUND
+// - ERROR_NO_SUCH_LOGON_SESSION
+// - ERROR_INVALID_FLAGS
+//
+// https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-credreadw
+// - ERROR_NOT_FOUND
+// - ERROR_NO_SUCH_LOGON_SESSION
+// - ERROR_INVALID_FLAGS
+// - invalid utf8 error
+//
+// https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-credwritew
+// - ERROR_NO_SUCH_LOGON_SESSION
+// - ERROR_INVALID_PARAMETER
+// - ERROR_INVALID_FLAGS
+// - ERROR_BAD_USERNAME
+// - ERROR_NOT_FOUND
+// - SCARD_E_NO_SMARTCARD
+// - SCARD_W_REMOVED_CARD
+// - SCARD_WRONG_CHV
+//
+// MacOs
+// Match on Error.code() (OSStatus)
+// https://docs.rs/security-framework/0.4.2-alpha.1/security_framework/base/struct.Error.html
+// https://developer.apple.com/documentation/security/1542001-security_framework_result_codes?language=objc
+// Check list for all the i32 codes.
+// e.g.
+// https://developer.apple.com/documentation/security/1542001-security_framework_result_codes/errsecitemnotfound?language=objc
+// errSecItemNotFound, -25300
+//
+// Linux
+// Most secret service errors are currently transmitted as Dbus errors.
+// https://specifications.freedesktop.org/secret-service/latest/ch15.html
+// - IsLocked
+// - NoSession
+// - NoSuchObject
+//
+// I probably need to reconsider cleaning up secret service errors also.
+
 #[cfg(target_os = "linux")]
 use secret_service::SsError;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Cleaning up and unifying error handling.

Currently, there are two issues with error handling in keyring:
- errors like ItemNotFound are not unified across platforms
- Error information from platform is lost when error is mapped to a more generic KeyringError.

This PR will at least make an ItemNotFound error consistent across platforms.

I hope to also reintroduce better error reporting from individual platforms, and see if other errors can be unified.

Implementation notes (on OS specific codes, etc.) are in the error module.