### PR TITLE
Remove usage of deprecated Error API (description and cause).

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -40,21 +40,7 @@ impl fmt::Display for KeyringError {
 }
 
 impl error::Error for KeyringError {
-    fn description(&self) -> &str {
-        match *self {
-            #[cfg(target_os = "macos")]
-            KeyringError::MacOsKeychainError(ref err) => err.description(),
-            #[cfg(target_os = "linux")]
-            KeyringError::SecretServiceError(ref err) => err.description(),
-            #[cfg(target_os = "windows")]
-            KeyringError::WindowsVaultError => "Windows Vault Error",
-            KeyringError::NoBackendFound => "No Backend Found",
-            KeyringError::NoPasswordFound => "No Password Found",
-            KeyringError::Parse(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             #[cfg(target_os = "linux")]
             KeyringError::SecretServiceError(ref err) => Some(err),


### PR DESCRIPTION
Both description() and cause() on std::error::Error have been deprecated for a bit now (since rust 1.42 and 1.33 respectively). This patch removes description() to simply rely on the Display implementation and simply changes the cause() implementation to be source().

Since the Display and description() implementations were different, I wasn't sure which version you'd prefer to keep. I started with the just removing description() to keep the number of diffs down and if you decided you wanted this PR I can update as you so desire. :)