### PR TITLE
get_password() on macos can now report a NoPasswordFound error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,4 +85,11 @@ mod tests {
 
         keyring.delete_password().unwrap();
     }
+
+    #[test]
+    fn test_error_for_no_password_found() {
+        let keyring = Keyring::new(TEST_SERVICE, TEST_USER);
+        let result = keyring.get_password();
+        assert!(matches!(result, Err(KeyringError::NoPasswordFound)));
+    }
 }


### PR DESCRIPTION
I wanted to use get_password() to determine if a password already existed in the macos keychain but this was difficult without having to write platform-specific code since all errors on macos would get swallowed up into the generic MacOsKeychainError. This patch specifically looks for the errSecItemNotFound OSStatus in the error returned from the security-framework crate and maps that into a NoPasswordFound error.