### PR TITLE
Change Keyring construction to make it constant

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -6,24 +6,32 @@ use std::path::Path;
 pub struct Keyring<'a> {
     service: &'a str,
     username: &'a str,
-    path: Option<&'a Path>
+    path: Option<&'a Path>,
 }
 
 // Eventually try to get collection into the Keyring struct?
 impl<'a> Keyring<'a> {
-    pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
-        Keyring { service, username, path: None }
+    pub const fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
+        Keyring {
+            service,
+            username,
+            path: None,
+        }
     }
 
     #[cfg(feature = "macos-specify-keychain")]
     pub fn use_keychain(service: &'a str, username: &'a str, path: &'a Path) -> Keyring<'a> {
-        Keyring { service, username, path: Some(path) }
+        Keyring {
+            service,
+            username,
+            path: Some(path),
+        }
     }
 
     fn get_keychain(&self) -> security_framework::base::Result<SecKeychain> {
         match self.path {
             Some(path) => SecKeychain::open(path),
-            _ => SecKeychain::default()
+            _ => SecKeychain::default(),
         }
     }
 
@@ -38,7 +46,8 @@ impl<'a> Keyring<'a> {
     }
 
     pub fn get_password(&self) -> Result<String> {
-        let (password_bytes, _) = find_generic_password(Some(&[self.get_keychain()?]), self.service, self.username)?;
+        let (password_bytes, _) =
+            find_generic_password(Some(&[self.get_keychain()?]), self.service, self.username)?;
 
         // Mac keychain allows non-UTF8 values, but this library only supports adding UTF8 items
         // to the keychain, so this should only fail if we are trying to retrieve a non-UTF8
@@ -50,7 +59,8 @@ impl<'a> Keyring<'a> {
     }
 
     pub fn delete_password(&self) -> Result<()> {
-        let (_, item) = find_generic_password(Some(&[self.get_keychain()?]), self.service, self.username)?;
+        let (_, item) =
+            find_generic_password(Some(&[self.get_keychain()?]), self.service, self.username)?;
 
         item.delete();
 
@@ -97,7 +107,9 @@ mod test {
         let temp_keychain_path = dir.path().join("Temporary.keychain");
         dbg!(&temp_keychain_path);
         let temp_keychain = keychain::CreateOptions::new();
-        temp_keychain.create(&temp_keychain_path).expect("Could not create temp keychain");
+        temp_keychain
+            .create(&temp_keychain_path)
+            .expect("Could not create temp keychain");
         let keyring = Keyring::use_keychain("testservice", "testuser", &temp_keychain_path);
 
         keyring.set_password(password_1).unwrap();

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -29,7 +29,7 @@ pub struct Keyring<'a> {
 }
 
 impl<'a> Keyring<'a> {
-    pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
+    pub const fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
         Keyring { service, username }
     }
 


### PR DESCRIPTION
This allows code doing things like:
```rust
const KEYRING: Keyring = Keyring::new(service, username);
```