### PR TITLE
Add missing feature on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ secret-service = "1.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2.1"
-winapi = { version =  "0.3", features = ["wincred", "minwindef"] }
+winapi = { version = "0.3", features = ["wincred", "minwindef", "winerror", "errhandlingapi"] }
 
 [dev-dependencies]
 clap = "2.0.5"


### PR DESCRIPTION
If this feature is not enabled, libraries that use keyring would fail with the following message:
```
error[E0432]: unresolved import `winapi::shared::winerror`
  --> C:\Users\xxxx\scoop\persist\rustup\.cargo\git\checkouts\keyring-rs-b52068140faa8a8e\d4f0c1a\src\windows.rs:10:21
   |
10 | use winapi::shared::winerror::{ERROR_NOT_FOUND, ERROR_NO_SUCH_LOGON_SESSION};
   |                     ^^^^^^^^ could not find `winerror` in `shared`

error[E0432]: unresolved import `winapi::um::errhandlingapi`
  --> C:\Users\xxxx\scoop\persist\rustup\.cargo\git\checkouts\keyring-rs-b52068140faa8a8e\d4f0c1a\src\windows.rs:11:17
   |
11 | use winapi::um::errhandlingapi::GetLastError;
   |                 ^^^^^^^^^^^^^^ could not find `errhandlingapi` in `um`
```