### PR TITLE
Update secret service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ macos-specify-keychain = []
 security-framework = "0.4.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-secret-service = "1.1.1"
+secret-service = "2.0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,18 @@ secret-service = "1.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2.1"
-winapi = { version =  "0.3", features = ["wincred", "minwindef"] }
+windows = "0.6.0"
 
 [dev-dependencies]
 clap = "2.0.5"
 rpassword = "2.0.0"
 
+[dependencies]
+thiserror = "1.0.24"
+
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 keychain-services = "0.1.1"
 tempfile = "3.1.0"
+
+[target.'cfg(target_os = "windows")'.build-dependencies]
+windows = "0.4.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(target_os = "windows")]
+    windows::build!(
+        windows::security::credentials::*,
+    );
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::string::{FromUtf16Error, FromUtf8Error};
 use thiserror::Error;
 
 #[cfg(target_os = "linux")]
-use secret_service::SsError as OsError;
+use secret_service::Error as OsError;
 #[cfg(target_os = "macos")]
 use security_framework::base::Error as OsError;
 #[cfg(target_os = "windows")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use linux::Keyring;
 #[cfg(target_os = "windows")]
 mod windows;
 #[cfg(target_os = "windows")]
-pub use windows::Keyring;
+pub use crate::windows::Keyring;
 
 // Configure for OSX
 #[cfg(target_os = "macos")]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
+
 use secret_service::{EncryptionType, SecretService};
 
 use crate::error::{KeyringError, ParseError, Result};
 
 pub struct Keyring<'a> {
-    attributes: Vec<(&'a str, &'a str)>,
+    attributes: HashMap<&'a str, &'a str>,
     service: &'a str,
     username: &'a str,
 }
@@ -11,7 +13,9 @@ pub struct Keyring<'a> {
 // Eventually try to get collection into the Keyring struct?
 impl<'a> Keyring<'a> {
     pub fn new(service: &'a str, username: &'a str) -> Keyring<'a> {
-        let attributes = vec![("service", service), ("username", username)];
+        let mut attributes = HashMap::new();
+        attributes.insert("service", service);
+        attributes.insert("username", username);
         Keyring {
             attributes,
             service,
@@ -26,7 +30,7 @@ impl<'a> Keyring<'a> {
             collection.unlock()?;
         }
         let mut attrs = self.attributes.clone();
-        attrs.push(("application", "rust-keyring"));
+        attrs.insert("application", "rust-keyring");
         let label = &format!("Password for {} on {}", self.username, self.service)[..];
         collection.create_item(
             label,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,5 +1,6 @@
-use crate::error::{KeyringError, Result};
 use secret_service::{EncryptionType, SecretService};
+
+use crate::error::{KeyringError, ParseError, Result};
 
 pub struct Keyring<'a> {
     attributes: Vec<(&'a str, &'a str)>,
@@ -46,7 +47,7 @@ impl<'a> Keyring<'a> {
         let search = collection.search_items(self.attributes.clone())?;
         let item = search.get(0).ok_or(KeyringError::NoPasswordFound)?;
         let secret_bytes = item.get_secret()?;
-        let secret = String::from_utf8(secret_bytes)?;
+        let secret = String::from_utf8(secret_bytes).map_err(ParseError::Utf8)?;
         Ok(secret)
     }
 


### PR DESCRIPTION
This enables services that depend on errors being Send + Sync and secret-service moved to zbus which supports it.
(Newer dbus versions also implement it)

This is dependant on https://github.com/hwchen/keyring-rs/pull/58 as it already changes the errors to thiserror