### PR TITLE
Allow explicit target for get_password

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -91,13 +91,17 @@ impl<'a> Keyring<'a> {
     }
 
     pub fn get_password(&self) -> Result<String> {
+        let target_name: String = [self.username, self.service].join(".");
+        self.get_password_for_target(&target_name)
+    }
+
+    pub fn get_password_for_target(&self, target_name: &str) -> Result<String> {
         // passing uninitialized pcredential.
         // Should be ok; it's freed by a windows api
         // call CredFree.
         let mut pcredential = MaybeUninit::uninit();
 
-        let target_name: String = [self.username, self.service].join(".");
-        let target_name = to_wstr(&target_name);
+        let target_name = to_wstr(target_name);
 
         let cred_type = CRED_TYPE_GENERIC;
 


### PR DESCRIPTION
This is a windows-only change, because it's a windows-only problem.  We add a second form of get_password called `get_password_for_target`.  This fixes issue #60.

This change is fully backward-compatible in the semver sense, so it can be allowed as a minor version change (new functionality).