### PR TITLE
Add credential get and set methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ secret-service = "1.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2.1"
-winapi = { version =  "0.3", features = ["wincred", "minwindef"] }
+winapi = { version =  "0.3", features = ["wincred", "minwindef", "winerror"] }
 
 [dev-dependencies]
 clap = "2.0.5"


### PR DESCRIPTION
I'm somewhat of a noob so I feel free to criticize if this is the wrong approach. Basically I needed to be able to get username/password pairs from existing ones set by other applications and be able to set ones that other applications can use without using the . separator. There is probably a better way to do this, but I just wanted to get discussion going.

This PR shouldn't be merged as-is, as it would make windows behave differently from the other platforms, though I'm not sure of the best way to do this as I don't own a macintosh so I don't know what caveats need to be dealt with on that platform. Plus I did a few things obviously wrong, like having code duplication where it isn't necessary, though I didn't want to spend too much time as I'm 99% sure somebody will have a better approach that would render all of that work useless.

Anyways, let me know what you think :)