### PR TITLE
Expose docstring-like comments to the docs

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -42,10 +42,10 @@ pub enum Platform {
     MacOs,
 }
 
-// Linux supports multiple credential stores, each named by a string.
-// Credentials in a store are identified by an arbitrary collection
-// of attributes, and each can have "label" metadata for use in
-// graphical editors.
+/// Linux supports multiple credential stores, each named by a string.
+/// Credentials in a store are identified by an arbitrary collection
+/// of attributes, and each can have "label" metadata for use in
+/// graphical editors.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LinuxCredential {
     pub collection: String,
@@ -54,10 +54,10 @@ pub struct LinuxCredential {
 }
 
 impl LinuxCredential {
-    // Using strings in the credential map makes managing the lifetime
-    // of the credential much easier.  But since the secret service expects
-    // a map from &str to &str, we have this utility to transform the
-    // credential's map into one of the right form.
+    /// Using strings in the credential map makes managing the lifetime
+    /// of the credential much easier.  But since the secret service expects
+    /// a map from &str to &str, we have this utility to transform the
+    /// credential's map into one of the right form.
     pub fn attributes(&self) -> HashMap<&str, &str> {
         self.attributes
             .iter()
@@ -66,9 +66,9 @@ impl LinuxCredential {
     }
 }
 
-// Windows has only one credential store, and each credential is identified
-// by a single string called the "target name".  But generic credentials
-// also have three pieces of metadata with suggestive names.
+/// Windows has only one credential store, and each credential is identified
+/// by a single string called the "target name".  But generic credentials
+/// also have three pieces of metadata with suggestive names.
 #[derive(Debug, Clone, PartialEq)]
 pub struct WinCredential {
     pub username: String,
@@ -77,10 +77,10 @@ pub struct WinCredential {
     pub comment: String,
 }
 
-// MacOS supports multiple OS-provided credential stores, and used to support creating
-// arbitrary new credential stores (but that has been deprecated).  Credentials on
-// Mac also can have "type" but we don't reflect that here because the type is actually
-// opaque once set and is only used in the Keychain UI.
+/// MacOS supports multiple OS-provided credential stores, and used to support creating
+/// arbitrary new credential stores (but that has been deprecated).  Credentials on
+/// Mac also can have "type" but we don't reflect that here because the type is actually
+/// opaque once set and is only used in the Keychain UI.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MacCredential {
     pub domain: MacKeychainDomain,
@@ -133,8 +133,8 @@ impl PlatformCredential {
     }
 }
 
-// Create the default target credential for a keyring item.  The caller
-// can provide a target parameter to influence the mapping.
+/// Create the default target credential for a keyring item.  The caller
+/// can provide a target parameter to influence the mapping.
 pub fn default_target(
     platform: &Platform,
     target: Option<&str>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,34 +1,34 @@
 #[derive(Debug)]
 pub enum Error {
-    // This indicates runtime failure in the underlying
-    // platform storage system.  The details of the failure can
-    // be retrieved from the attached platform error.
+    /// This indicates runtime failure in the underlying
+    /// platform storage system.  The details of the failure can
+    /// be retrieved from the attached platform error.
     PlatformFailure(crate::platform::Error),
-    // This indicates that the underlying secure storage
-    // holding saved items could not be accessed.  Typically this
-    // is because of access rules in the platform; for example, it
-    // might be that the credential store is locked.  The underlying
-    // platform error will typically give the reason.
+    /// This indicates that the underlying secure storage
+    /// holding saved items could not be accessed.  Typically this
+    /// is because of access rules in the platform; for example, it
+    /// might be that the credential store is locked.  The underlying
+    /// platform error will typically give the reason.
     NoStorageAccess(crate::platform::Error),
-    // This indicates that there is no underlying credential
-    // entry in the platform for this item.  Either one was
-    // never set, or it was deleted.
+    /// This indicates that there is no underlying credential
+    /// entry in the platform for this item.  Either one was
+    /// never set, or it was deleted.
     NoEntry,
-    // This indicates that the retrieved password blob was not
-    // a UTF-8 string.  The underlying bytes are available
-    // for examination in the attached value.
+    /// This indicates that the retrieved password blob was not
+    /// a UTF-8 string.  The underlying bytes are available
+    /// for examination in the attached value.
     BadEncoding(Vec<u8>),
-    // This indicates that one of the underlying credential
-    // metadata values produced by the mapper exceeded a
-    // length limit for the underlying platform.  The
-    // attached value give the name of the attribute and
-    // the platform length limit that was exceeded.
+    /// This indicates that one of the underlying credential
+    /// metadata values produced by the mapper exceeded a
+    /// length limit for the underlying platform.  The
+    /// attached value give the name of the attribute and
+    /// the platform length limit that was exceeded.
     TooLong(String, u32),
-    // This indicates that the underlying mapper produced
-    // a credential specification for a different platform
-    // that you are running on.  Since the mapper is only
-    // run when items are created, this can only be a status
-    // returned from `new_with_mapper`.
+    /// This indicates that the underlying mapper produced
+    /// a credential specification for a different platform
+    /// that you are running on.  Since the mapper is only
+    /// run when items are created, this can only be a status
+    /// returned from `new_with_mapper`.
     WrongCredentialPlatform,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,27 +25,27 @@ pub struct Entry {
 }
 
 impl Entry {
-    // Create an entry for the given service and username.
-    // This maps to a target credential in the default keychain.
+    /// Create an entry for the given service and username.
+    /// This maps to a target credential in the default keychain.
     pub fn new(service: &str, username: &str) -> Entry {
         Entry {
             target: credential::default_target(&platform(), None, service, username),
         }
     }
 
-    // Create an entry for the given target, service, and username.
-    // On Linux and Mac, the target is interpreted as naming the collection/keychain
-    // to store the credential.  On Windows, the target is used directly as
-    // the _target name_ of the credential.
+    /// Create an entry for the given target, service, and username.
+    /// On Linux and Mac, the target is interpreted as naming the collection/keychain
+    /// to store the credential.  On Windows, the target is used directly as
+    /// the _target name_ of the credential.
     pub fn new_with_target(target: &str, service: &str, username: &str) -> Entry {
         Entry {
             target: credential::default_target(&platform(), Some(target), service, username),
         }
     }
 
-    // Create an entry that uses the given credential for storage.  Callers can use
-    // their own algorithm to produce a platform-specific credential spec for the
-    // given service and username and then call this entry with that value.
+    /// Create an entry that uses the given credential for storage.  Callers can use
+    /// their own algorithm to produce a platform-specific credential spec for the
+    /// given service and username and then call this entry with that value.
     pub fn new_with_credential(target: &PlatformCredential) -> Result<Entry> {
         if target.matches_platform(&platform()) {
             Ok(Entry {
@@ -56,33 +56,33 @@ impl Entry {
         }
     }
 
-    // Set the password for this item.  Any other platform-specific
-    // annotations are determined by the mapper that was used
-    // to create the credential.
+    /// Set the password for this item.  Any other platform-specific
+    /// annotations are determined by the mapper that was used
+    /// to create the credential.
     pub fn set_password(&self, password: &str) -> Result<()> {
         platform::set_password(&self.target, password)
     }
 
-    // Retrieve the password saved for this item.
-    // Returns a `NoEntry` error is there isn't one.
+    /// Retrieve the password saved for this item.
+    /// Returns a `NoEntry` error is there isn't one.
     pub fn get_password(&self) -> Result<String> {
         let mut map = self.target.clone();
         platform::get_password(&mut map)
     }
 
-    // Retrieve the password and all the other fields
-    // set in the platform-specific credential.  This
-    // allows retrieving metadata on the credential that
-    // were saved by external applications.
+    /// Retrieve the password and all the other fields
+    /// set in the platform-specific credential.  This
+    /// allows retrieving metadata on the credential that
+    /// were saved by external applications.
     pub fn get_password_and_credential(&self) -> Result<(String, PlatformCredential)> {
         let mut map = self.target.clone();
         let password = platform::get_password(&mut map)?;
         Ok((password, map))
     }
 
-    // Delete the password for this item.  (Although the item
-    // itself follows the Rust structure lifecycle, deleting
-    // the password deletes the platform credential from secure storage.)
+    /// Delete the password for this item.  (Although the item
+    /// itself follows the Rust structure lifecycle, deleting
+    /// the password deletes the platform credential from secure storage.)
     pub fn delete_password(&self) -> Result<()> {
         platform::delete_password(&self.target)
     }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -62,8 +62,8 @@ fn decode_password(bytes: Vec<u8>) -> Result<String> {
     String::from_utf8(bytes.clone()).map_err(|_| ErrorCode::BadEncoding(bytes))
 }
 
-// The MacOS error codes used here are from:
-// https://opensource.apple.com/source/libsecurity_keychain/libsecurity_keychain-78/lib/SecBase.h.auto.html
+/// The MacOS error codes used here are from:
+/// https://opensource.apple.com/source/libsecurity_keychain/libsecurity_keychain-78/lib/SecBase.h.auto.html
 fn decode_error(err: Error) -> ErrorCode {
     match err.code() {
         -25291 => ErrorCode::NoStorageAccess(err), // errSecNotAvailable


### PR DESCRIPTION
Hello! Thanks for this library, and I hope this is not a nuisance PR or making a wrong assumption.

I noticed that the documentation generated with `cargo doc --open` was a little sparse, lacking descriptions for all the functions on `Entry` for example, despite there being excellent and helpful notes in the source code.

This commit changes the `//` regular comments to `///` docstring comments wherever they seemed like they might have been meant for documentation, so that they show up in the generated docs. Previous output from `cargo doc`:

<img width="905" alt="Screen Shot 2021-11-27 at 18 39 38" src="https://user-images.githubusercontent.com/205128/143723659-f7472e26-b212-4f78-9aff-c2344887d4ec.png">

with these changes:

<img width="903" alt="Screen Shot 2021-11-27 at 18 39 04" src="https://user-images.githubusercontent.com/205128/143723661-2e595be8-2d1a-4e76-affd-850dcdbedcf0.png">

It made it easier for me to use :)