### PR TITLE
Prevent the use of empty user, service, or target names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "examples/ios.rs"
 crate-type = ["staticlib"]
 
 [dev-dependencies]
-clap = { version = "3.0.14", features = ["derive"] }
+clap = { version = "3", features = ["derive", "wrap_help"] }
 rpassword = "5.0"
 rand = "0.8.4"
 doc-comment = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2018"
 exclude = [".github/"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2018"
 exclude = [".github/"]
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use this library in your project add the following to your `Cargo.toml` file:
 keyring = "1"
 ```
 
-This will give you access to the `keyring` crate in your code. Now you can use  the `Entry::new` function to create a new keyring entry. The `new` function expects a `service` name and an `username` which together identify the entry.
+This will give you access to the `keyring` crate in your code. Now you can use  the `Entry::new` function to create a new keyring entry. The `new` function expects a non-empty `service` name and a non-empty `username` which together identify the entry.
 
 Passwords can be added to an entry using its `set_password` method.  They can then be read back using the `get_password` method, and deleted using the `delete_password` method.  (The persistence of the `Entry` is determined via Rust rules, so deleting the password doesn't delete the entry, but it does delete the underlying platform credential which was used to store the password.)
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The application is a command-line interface to the keychain.  This can be a grea
 
 The sample library is a full exercise of all the iOS functionality; it's meant to be loaded into an iOS test harness such as the one found in [this project](https://github.com/brotskydotcom/rust-on-ios). While the library can be compiled and linked to on macOS as well, doing so doesn't provide any advantages over using standard Rust tests.
 
+## Known Issues
+
+Because credentials identified with empty service, user, or target names are handled inconsistently at the platform layer, the library had inconsistent (and arguably buggy - see [#86](https://github.com/hwchen/keyring-rs/issues/86)) behavior in this case.  As of version 1.2, this inconsistency was eliminated by having the library always fail on access when using credentials created with empty strings via `new` or `new_with_target`.  The prior platform-specific behavior can still be accessed, however, by using `new_with_credential` to produce the same credential that would have been produced before the change.
+
+A better way to handle empty strings (and other problematic argument values) would be to allow `Entry` creation to fail gracefully on arguments that are known not to work on a given platform.  That would be a breaking API change, however, so it will have to wait until the next major version.
+
 ## Dev Notes
 
 * We build using GitHub CI.

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -8,20 +8,20 @@ use keyring::{Entry, Error};
 #[clap(author = "github.com/hwchen/keyring-rs")]
 /// Keyring CLI: A command-line interface to platform secure storage
 pub struct Cli {
-    #[clap(short, parse(from_occurrences))]
+    #[clap(short, action = clap::ArgAction::Count)]
     /// Specify once to retrieve all aspects of credentials on get.
     /// Specify twice to provide structure print of all errors in addition to messages.
     pub verbose: u8,
 
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     /// The target for the entry.
     pub target: Option<String>,
 
-    #[clap(short, long, default_value = "keyring-cli")]
+    #[clap(short, long, value_parser, default_value = "keyring-cli")]
     /// The service name for the entry
     pub service: String,
 
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     /// The user name to store/retrieve the password for [default: user's login name]
     pub username: Option<String>,
 
@@ -33,6 +33,7 @@ pub struct Cli {
 pub enum Command {
     /// Set the password in the secure store
     Set {
+        #[clap(value_parser)]
         /// The password to set. If not specified, the password
         /// is collected interactively from the terminal
         password: Option<String>,

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -140,12 +140,12 @@ pub struct IosCredential {
 /// While defined cross-platform, instantiated platform
 /// credentials always contain just the model for the
 /// current runtime `Platform`.
-/// 
+///
 /// Because you can create credentials for any strings,
 /// but platform handling of empty target attributes is
 /// not well defined, we have a special Invalid case
 /// which we use in this case to ensure the created
-/// credential has no functionality. 
+/// credential has no functionality.
 pub enum PlatformCredential {
     Linux(LinuxCredential),
     Win(WinCredential),

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -140,11 +140,18 @@ pub struct IosCredential {
 /// While defined cross-platform, instantiated platform
 /// credentials always contain just the model for the
 /// current runtime `Platform`.
+/// 
+/// Because you can create credentials for any strings,
+/// but platform handling of empty target attributes is
+/// not well defined, we have a special Invalid case
+/// which we use in this case to ensure the created
+/// credential has no functionality. 
 pub enum PlatformCredential {
     Linux(LinuxCredential),
     Win(WinCredential),
     Mac(MacCredential),
     Ios(IosCredential),
+    Invalid,
 }
 
 impl PlatformCredential {
@@ -154,18 +161,26 @@ impl PlatformCredential {
             PlatformCredential::Win(_) => matches!(os, Platform::Windows),
             PlatformCredential::Mac(_) => matches!(os, Platform::MacOs),
             PlatformCredential::Ios(_) => matches!(os, Platform::Ios),
+            PlatformCredential::Invalid => false,
         }
     }
 }
 
 /// Create the default target credential for a keyring entry.  The caller
 /// can provide an optional target parameter to influence the mapping.
+///
+/// If any of the provided strings are empty, the credential returned is
+/// invalid, to prevent it being used.  This is because platform behavior
+/// around empty strings for attributes is undefined.
 pub fn default_target(
     platform: &Platform,
     target: Option<&str>,
     service: &str,
     username: &str,
 ) -> PlatformCredential {
+    if service.is_empty() || username.is_empty() || target.unwrap_or("none").is_empty() {
+        return PlatformCredential::Invalid;
+    }
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     let custom = if target.is_none() {
         "entry"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@ This module manipulates passwords as UTF-8 encoded strings, so if a third party 
 
 Accessing the same keychain entry from multiple threads simultaneously can produce odd results, even deadlocks.  This is because the system calls to the platform credential managers may use the same thread discipline, and so may be serialized quite differently than the client-side calls.  On MacOS, for example, all calls to access the keychain are serialized in an order that is independent of when they are made.
 
+Because credentials identified with empty service, user, or target names are handled inconsistently at the platform layer, the library had inconsistent (and arguably buggy) behavior in this case.  As of version 1.2, this inconsistency was eliminated by having the library always fail on access when using credentials created with empty strings via `new` or `new_with_target`.  The prior platform-specific behavior can still be accessed by using `new_with_credential` to produce the same credential that would have been produced before the change.
+
+A better way to handle empty strings (and other problematic argument values) would be to allow `Entry` creation to fail gracefully on arguments that are known not to work on a given platform.  That would be a breaking API change, however, so it will have to wait until the next major version.
+
  */
 pub mod credential;
 pub mod error;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -208,7 +208,7 @@ fn extract_password(credential: &CREDENTIALW) -> Result<String> {
     // Now we know this _can_ be a UTF-16 string, so convert it to
     // as UTF-16 vector and then try to decode it.
     let mut blob_u16 = vec![0; blob.len() / 2];
-    LittleEndian::read_u16_into(&blob.to_vec(), &mut blob_u16);
+    LittleEndian::read_u16_into(blob, &mut blob_u16);
     String::from_utf16(&blob_u16).map_err(|_| ErrorCode::BadEncoding(blob.to_vec()))
 }
 


### PR DESCRIPTION
This PR fixes hwchen/keyring-rs#86.

Since we can't alter the API to prevent the creation of credentials that have empty strings for target, service, or user names, we instead create "always invalid" credentials that, while well-formed, do no support calling get_password or set_password successfully.  (They always return a `NoEntry` error.)

The docs (both top-level and code-level) have been updated, and tests added to verify this handling.