### PR TITLE
Update secret-service-rs to 2.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ security-framework = "2.6.1"
 security-framework = "2.6.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-secret-service = "2.0.1"
+secret-service = "2.0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2.1"


### PR DESCRIPTION
This PR updates the [secret-service-rs](https://github.com/hwchen/secret-service-rs) crate from 2.0.1 to 2.0.2. It looks like the new version was released 5 days ago.

I believe this should fix this dependabot alert I am getting on one of my [repos](https://github.com/ciehanski/kip/security/dependabot/21).