### PR TITLE
Update rpassword to its latest major version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ crate-type = ["staticlib"]
 
 [dev-dependencies]
 clap = { version = "3", features = ["derive", "wrap_help"] }
-rpassword = "5.0"
+rpassword = "6.0"
 rand = "0.8"
 doc-comment = "0.3"
 whoami = "1.2"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use rpassword::read_password_from_tty;
+use rpassword::prompt_password;
 
 extern crate keyring;
 use keyring::{Entry, Error};
@@ -65,7 +65,7 @@ fn execute_args(args: &Cli) {
             password: Some(password),
         } => execute_set_password(&username, args.verbose, &entry, password),
         Command::Set { password: None } => {
-            if let Ok(password) = read_password_from_tty(Some("Password: ")) {
+            if let Ok(password) = prompt_password("Password: ") {
                 execute_set_password(&username, args.verbose, &entry, &password)
             } else {
                 eprintln!("(Failed to read password, so none set.)")


### PR DESCRIPTION
It had a breaking API change, so this required updating the cli example as well.

(This was change suggested by dependabot.  It's definitely not worth doing a release for, but we should have it ready for the next release.)