### PR TITLE
Add keyutils as an alternate keystore on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ version = "2.0.0-alpha.1"
 edition = "2021"
 exclude = [".github/"]
 
+[features]
+default = ["linux-secret-service"]
+linux-secret-service = []
+linux-keyutils = []
+
 [dependencies]
 lazy_static = "1"
 
@@ -21,6 +26,7 @@ security-framework = "2.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = "2.0"
+linux-keyutils = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 edition = "2021"
 exclude = [".github/"]
 
@@ -26,7 +26,7 @@ security-framework = "2.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = "2.0"
-linux-keyutils = "0.2"
+linux-keyutils = { version = "0.2", features = ["std"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 byteorder = "1.2"

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -1,0 +1,220 @@
+//! Example implementation of the keyring crate's trait interface
+//! using linux-keyutils
+use linux_keyutils::{KeyRing, KeyRingIdentifier};
+
+use super::credential::{Credential, CredentialApi, CredentialBuilder, CredentialBuilderApi};
+use super::error::{decode_password, Error as ErrorCode, Result};
+
+/// Since the CredentialBuilderApi::build method does not provide
+/// an initial secret, this wraps a linux_keyutils::KeyRing instead
+/// of a linux_keyutils::Key. Since it is impossible to have a
+/// zero-length key.
+///
+/// The added benefit is any call to get_password before set_password
+/// will result in a proper error as the key does not exist until
+/// set_password is called.
+#[derive(Debug, Clone)]
+pub struct KeyutilsCredential {
+    /// Host keyring
+    pub inner: KeyRing,
+    /// Description of the key entry
+    pub description: String,
+}
+
+impl CredentialApi for KeyutilsCredential {
+    /// Set a password in the underlying store
+    ///
+    /// This will overwrite the entry if it already exists since
+    /// it's using `add_key` under the hood.
+    fn set_password(&self, password: &str) -> Result<()> {
+        self.inner
+            .add_key(&self.description, password)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?;
+        Ok(())
+    }
+
+    /// Retrieve a password from the underlying store
+    ///
+    /// This requires a call to `Key::read` with checked conversions
+    /// to a utf8 Rust string.
+    fn get_password(&self) -> Result<String> {
+        // Verify that the key exists and is valid
+        let key = self
+            .inner
+            .search(&self.description)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?;
+        // Read in the key (making sure we have enough room)
+        let mut buffer = vec![0u8; 65535];
+        let len = key
+            .read(&mut buffer)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?;
+        unsafe {
+            buffer.set_len(len);
+        }
+        // Attempt utf-8 conversion
+        decode_password(buffer)
+    }
+
+    /// Delete a password from the underlying store.
+    ///
+    /// Under the hood this uses `Key::invalidate` to immediately
+    /// invalidate the key and prevent any further successful
+    /// searches.
+    fn delete_password(&self) -> Result<()> {
+        // Verify that the key exists and is valid
+        let key = self
+            .inner
+            .search(&self.description)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?;
+        // Invalidate the key immediately
+        key.invalidate()
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?;
+        Ok(())
+    }
+
+    /// Cast the credential object to std::any::Any.  This allows clients
+    /// to downcast the credential to its concrete type so they
+    /// can do platform-specific things with it (e.g, unlock it)
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl KeyutilsCredential {
+    /// Construct a credential from the underlying platform credential
+    /// This is basically a no-op, because we don't keep any extra attributes.
+    /// But at least we make sure the underlying platform credential exists.
+    pub fn get_credential(&self) -> Result<Self> {
+        self.inner
+            .search(&self.description)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?;
+        Ok(self.clone())
+    }
+
+    /// Create the platform credential for a Keyutils entry.
+    ///
+    /// A target string is interpreted as the KeyRing to use for the entry.
+    pub fn new_with_target(target: Option<&str>, service: &str, user: &str) -> Result<Box<Self>> {
+        // Construct the credential with a URI-style description
+        Ok(Box::new(Self {
+            inner: keyring_from_target(target)?,
+            description: format!("keyring-rs:{}@{}", user, service),
+        }))
+    }
+}
+
+/// Simple abstraction around building access to a persistent
+/// keyring.
+#[derive(Debug, Copy, Clone)]
+struct KeyutilsCredentialBuilder {}
+
+/// A keyutils credential builder based off the persistent user-session
+/// keyring.
+impl CredentialBuilderApi for KeyutilsCredentialBuilder {
+    /// Attempt to access the persistent user-session keyring. The
+    /// keyring::Entry will be invalid until Entry::set_password is set.
+    fn build(&self, target: Option<&str>, service: &str, user: &str) -> Result<Box<Credential>> {
+        KeyutilsCredential::new_with_target(target, service, user)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn keyring_from_target(target: Option<&str>) -> Result<KeyRing> {
+    match target.unwrap_or("UserSession") {
+        "UserSession" => Ok(KeyRing::get_persistent(KeyRingIdentifier::UserSession)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?),
+        "UserSession.transient" => Ok(KeyRing::from_special_id(
+            KeyRingIdentifier::UserSession,
+            true,
+        )
+        .map_err(|e| ErrorCode::PlatformFailure(e.into()))?),
+        "Session" => KeyRing::get_persistent(KeyRingIdentifier::Session)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?,
+        "Session.transient" => Ok(KeyRing::from_special_id(KeyRingIdentifier::Session, true)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?),
+        "User" => KeyRing::get_persistent(KeyRingIdentifier::User)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?,
+        "User.transient" => Ok(KeyRing::from_special_id(KeyRingIdentifier::User, true)
+            .map_err(|e| ErrorCode::PlatformFailure(e.into()))?),
+        _ => Err(ErrorCode::Invalid(
+            "target".to_string(),
+            "must be one of User, Session, or UserSession, optionally followed by .transient"
+                .to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{tests::generate_random_string, tests::test_round_trip, Credential, Entry, Error};
+
+    use super::KeyutilsCredential;
+
+    fn entry_new(service: &str, user: &str) -> Entry {
+        crate::tests::entry_from_constructor(KeyutilsCredential::new_with_target, service, user)
+    }
+
+    #[test]
+    fn test_invalid_parameter() {
+        let credential = KeyutilsCredential::new_with_target(Some(""), "service", "user");
+        assert!(
+            matches!(credential, Err(Error::Invalid(_, _))),
+            "Created entry with empty target"
+        );
+    }
+
+    #[test]
+    fn test_empty_service_and_user() {
+        crate::tests::test_empty_service_and_user(entry_new);
+    }
+
+    #[test]
+    fn test_missing_entry() {
+        crate::tests::test_missing_entry(entry_new);
+    }
+
+    #[test]
+    fn test_empty_password() {
+        crate::tests::test_empty_password(entry_new);
+    }
+
+    #[test]
+    fn test_round_trip_ascii_password() {
+        crate::tests::test_round_trip_ascii_password(entry_new);
+    }
+
+    #[test]
+    fn test_round_trip_non_ascii_password() {
+        crate::tests::test_round_trip_non_ascii_password(entry_new);
+    }
+
+    #[test]
+    fn test_update() {
+        crate::tests::test_update(entry_new);
+    }
+
+    #[test]
+    fn test_get_credential() {
+        let name = generate_random_string();
+        let entry = entry_new(&name, &name);
+        let credential: &KeyutilsCredential = entry
+            .get_credential()
+            .downcast_ref()
+            .expect("Not a Keyutils credential");
+        assert!(
+            credential.get_credential().is_err(),
+            "Platform credential shouldn't exist yet!"
+        );
+        entry
+            .set_password("test get_credential")
+            .expect("Can't set password for get_credential");
+        assert!(credential.get_credential().is_ok());
+        entry
+            .delete_password()
+            .expect("Couldn't delete after get_credential");
+        assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,21 @@ Because credentials identified with empty service, user, or target names are han
 A better way to handle empty strings (and other problematic argument values) would be to allow `Entry` creation to fail gracefully on arguments that are known not to work on a given platform.  That would be a breaking API change, however, so it will have to wait until the next major version.
 
  */
+pub use credential::{Credential, CredentialBuilder};
+pub use error::{Error, Result};
+#[cfg(target_os = "ios")]
+use ios as default;
+#[cfg(all(target_os = "linux", feature = "linux-keyutils"))]
+use keyutils as default;
+#[cfg(target_os = "macos")]
+use macos as default;
+#[cfg(target_os = "windows")]
+use windows as default;
+
+// Set the default keystore on each platform
+#[cfg(all(target_os = "linux", feature = "linux-secret-service"))]
+use crate::secret_service as default;
+
 pub mod credential;
 pub mod error;
 pub mod mock;
@@ -118,21 +133,6 @@ pub mod macos;
 pub mod secret_service;
 #[cfg(target_os = "windows")]
 pub mod windows;
-
-// Set the default keystore on each platform
-#[cfg(target_os = "ios")]
-use ios as default;
-#[cfg(all(target_os = "linux", feature = "linux-keyutils"))]
-use keyutils as default;
-#[cfg(target_os = "macos")]
-use macos as default;
-#[cfg(all(target_os = "linux", feature = "linux-secret-service"))]
-use secret_service as default;
-#[cfg(target_os = "windows")]
-use windows as default;
-
-pub use credential::{Credential, CredentialBuilder};
-pub use error::{Error, Result};
 
 #[derive(Default, Debug)]
 struct EntryBuilder {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -177,23 +177,12 @@ fn decode_error(err: Error) -> ErrorCode {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        tests::{generate_random_string, test_round_trip},
-        Credential, Entry, Error,
-    };
+    use crate::{tests::generate_random_string, Entry, Error};
 
     use super::MacCredential;
 
     fn entry_new(service: &str, user: &str) -> Entry {
-        match MacCredential::new_with_target(None, service, user) {
-            Ok(credential) => {
-                let credential: Box<Credential> = Box::new(credential);
-                Entry::new_with_credential(credential)
-            }
-            Err(err) => {
-                panic!("Couldn't create entry (service: {service}, user: {user}): {err:?}")
-            }
-        }
+        crate::tests::entry_from_constructor(MacCredential::new_with_target, service, user)
     }
 
     #[test]
@@ -217,45 +206,27 @@ mod tests {
 
     #[test]
     fn test_missing_entry() {
-        let name = generate_random_string();
-        let entry = entry_new(&name, &name);
-        assert!(
-            matches!(entry.get_password(), Err(Error::NoEntry)),
-            "Missing entry has password"
-        )
+        crate::tests::test_missing_entry(entry_new);
     }
 
     #[test]
     fn test_empty_password() {
-        let name = generate_random_string();
-        let entry = entry_new(&name, &name);
-        test_round_trip("empty password", &entry, "");
+        crate::tests::test_empty_password(entry_new);
     }
 
     #[test]
     fn test_round_trip_ascii_password() {
-        let name = generate_random_string();
-        let entry = entry_new(&name, &name);
-        test_round_trip("ascii password", &entry, "test ascii password");
+        crate::tests::test_round_trip_ascii_password(entry_new);
     }
 
     #[test]
     fn test_round_trip_non_ascii_password() {
-        let name = generate_random_string();
-        let entry = entry_new(&name, &name);
-        test_round_trip("non-ascii password", &entry, "このきれいな花は桜です");
+        crate::tests::test_round_trip_non_ascii_password(entry_new);
     }
 
     #[test]
     fn test_update() {
-        let name = generate_random_string();
-        let entry = entry_new(&name, &name);
-        test_round_trip("initial ascii password", &entry, "test ascii password");
-        test_round_trip(
-            "updated non-ascii password",
-            &entry,
-            "このきれいな花は桜です",
-        );
+        crate::tests::test_update(entry_new);
     }
 
     #[test]
@@ -271,12 +242,12 @@ mod tests {
             "Platform credential shouldn't exist yet!"
         );
         entry
-            .set_password("test get password")
+            .set_password("test get_credential")
             .expect("Can't set password for get_credential");
         assert!(credential.get_credential().is_ok());
         entry
             .delete_password()
-            .expect("Couldn't delete get-credential");
+            .expect("Couldn't delete after get_credential");
         assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
     }
 }

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -11,13 +11,13 @@ use super::error::{decode_password, Error as ErrorCode, Result};
 /// of attributes, and each can have "label" metadata for use in
 /// graphical editors.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LinuxCredential {
+pub struct SsCredential {
     pub collection: String,
     pub attributes: HashMap<String, String>,
     pub label: String,
 }
 
-impl CredentialApi for LinuxCredential {
+impl CredentialApi for SsCredential {
     fn set_password(&self, password: &str) -> Result<()> {
         let ss = SecretService::new(EncryptionType::Dh).map_err(platform_failure)?;
         let collection = self.get_collection(&ss)?;
@@ -60,7 +60,7 @@ impl CredentialApi for LinuxCredential {
     }
 }
 
-impl LinuxCredential {
+impl SsCredential {
     /// Construct a credential from the underlying platform credential
     pub fn get_credential(&self) -> Result<Self> {
         let mut result = self.clone();
@@ -126,15 +126,15 @@ impl LinuxCredential {
     }
 }
 
-pub struct LinuxCredentialBuilder {}
+pub struct SsCredentialBuilder {}
 
 pub fn default_credential_builder() -> Box<CredentialBuilder> {
-    Box::new(LinuxCredentialBuilder {})
+    Box::new(SsCredentialBuilder {})
 }
 
-impl CredentialBuilderApi for LinuxCredentialBuilder {
+impl CredentialBuilderApi for SsCredentialBuilder {
     fn build(&self, target: Option<&str>, service: &str, user: &str) -> Result<Box<Credential>> {
-        Ok(Box::new(LinuxCredential::new_with_target(
+        Ok(Box::new(SsCredential::new_with_target(
             target, service, user,
         )?))
     }
@@ -174,15 +174,15 @@ fn wrap(err: Error) -> Box<dyn std::error::Error + Send + Sync> {
 mod tests {
     use crate::{tests::generate_random_string, Entry, Error};
 
-    use super::LinuxCredential;
+    use super::SsCredential;
 
     fn entry_new(service: &str, user: &str) -> Entry {
-        crate::tests::entry_from_constructor(LinuxCredential::new_with_target, service, user)
+        crate::tests::entry_from_constructor(SsCredential::new_with_target, service, user)
     }
 
     #[test]
     fn test_invalid_parameter() {
-        let credential = LinuxCredential::new_with_target(Some(""), "service", "user");
+        let credential = SsCredential::new_with_target(Some(""), "service", "user");
         assert!(
             matches!(credential, Err(Error::Invalid(_, _))),
             "Created entry with empty target"
@@ -226,7 +226,7 @@ mod tests {
         entry
             .set_password("test get credential")
             .expect("Can't set password for get_credential");
-        let credential: &LinuxCredential = entry
+        let credential: &SsCredential = entry
             .get_credential()
             .downcast_ref()
             .expect("Not a linux credential");


### PR DESCRIPTION
Now we have two keystores on Linux: secret-service v2 (the default), and keyutils (the alternate).  Features can be used to determine which is the default store used.