### PR TITLE
Take the dependabot update and simplify the CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 edition = "2021"
 exclude = [".github/"]
 
@@ -38,7 +38,7 @@ path = "examples/ios.rs"
 crate-type = ["staticlib"]
 
 [dev-dependencies]
-clap = { version = "3", features = ["derive", "wrap_help"] }
+clap = { version = "4", features = ["derive", "wrap_help"] }
 rpassword = "7.0"
 rand = "0.8"
 doc-comment = "0.3"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,18 +1,14 @@
+extern crate keyring;
+
 use clap::Parser;
 use rpassword::prompt_password;
 
-extern crate keyring;
 use keyring::{Entry, Error};
 
 #[derive(Debug, Parser)]
 #[clap(author = "github.com/hwchen/keyring-rs")]
 /// Keyring CLI: A command-line interface to platform secure storage
 pub struct Cli {
-    #[clap(short, action = clap::ArgAction::Count)]
-    /// Specify once to retrieve all aspects of credentials on get.
-    /// Specify twice to provide structure print of all errors in addition to messages.
-    pub verbose: u8,
-
     #[clap(short, long, value_parser)]
     /// The target for the entry.
     pub target: Option<String>,
@@ -21,9 +17,9 @@ pub struct Cli {
     /// The service name for the entry
     pub service: String,
 
-    #[clap(short, long, value_parser)]
-    /// The user name to store/retrieve the password for [default: user's login name]
-    pub username: Option<String>,
+    #[clap(short, long, value_parser, default_value = "")]
+    /// The user to store/retrieve the password for [default: user's login name]
+    pub user: String,
 
     #[clap(subcommand)]
     pub command: Command,
@@ -45,82 +41,85 @@ pub enum Command {
 }
 
 fn main() {
-    let args: Cli = Cli::parse();
+    let mut args: Cli = Cli::parse();
+    if args.user.is_empty() {
+        args.user = whoami::username()
+    }
     execute_args(&args);
 }
 
 fn execute_args(args: &Cli) {
-    let username = if let Some(username) = &args.username {
-        username.clone()
-    } else {
-        whoami::username()
-    };
     let entry = if let Some(target) = &args.target {
-        Entry::new_with_target(target, &args.service, &username)
+        Entry::new_with_target(target, &args.service, &args.user)
             .unwrap_or_else(|err| panic!("Couldn't create entry: {:?}", err))
     } else {
-        Entry::new(&args.service, &username)
+        Entry::new(&args.service, &args.user)
             .unwrap_or_else(|err| panic!("Couldn't create entry: {:?}", err))
     };
     match &args.command {
         Command::Set {
             password: Some(password),
-        } => execute_set_password(&username, args.verbose, &entry, password),
+        } => execute_set_password(&args, &entry, password),
         Command::Set { password: None } => {
             if let Ok(password) = prompt_password("Password: ") {
-                execute_set_password(&username, args.verbose, &entry, &password)
+                execute_set_password(&args, &entry, &password)
             } else {
                 eprintln!("(Failed to read password, so none set.)")
             }
         }
-        Command::Get => execute_get_password(&username, args.verbose, &entry),
-        Command::Delete => execute_delete_password(&username, args.verbose, &entry),
+        Command::Get => execute_get_password(&args, &entry),
+        Command::Delete => execute_delete_password(&args, &entry),
     }
 }
 
-fn execute_set_password(username: &str, verbose: u8, entry: &Entry, password: &str) {
+fn execute_set_password(args: &Cli, entry: &Entry, password: &str) {
     match entry.set_password(password) {
-        Ok(()) => println!("(Password for user '{}' set successfully)", username),
+        Ok(()) => {
+            println!(
+                "(Password for '{}@{}' set successfully)",
+                &args.user, &args.service
+            )
+        }
         Err(err) => {
-            eprintln!("Couldn't set password for user '{}': {}", username, err);
-            if verbose > 1 {
-                eprintln!("Error details: {:?}", err);
-            }
+            eprintln!(
+                "Couldn't set password for '{}@{}': {:?}",
+                &args.user, &args.service, err
+            );
         }
     }
 }
 
-fn execute_get_password(username: &str, verbose: u8, entry: &Entry) {
+fn execute_get_password(args: &Cli, entry: &Entry) {
     match entry.get_password() {
         Ok(password) => {
-            println!("The password for user '{}' is '{}'", username, &password);
+            println!(
+                "The password for '{}@{}' is '{}'",
+                &args.user, &args.service, &password
+            );
         }
         Err(Error::NoEntry) => {
-            eprintln!("(No password found for user '{}')", username);
+            eprintln!("(No password found for '{}@{}')", &args.user, &args.service);
         }
         Err(err) => {
-            eprintln!("Couldn't get password for user '{}': {}", username, err);
-            if verbose > 1 {
-                eprintln!("Error details: {:?}", err);
-            }
+            eprintln!(
+                "Couldn't get password for '{}@{}': {:?}",
+                &args.user, &args.service, err
+            );
         }
     }
 }
 
-fn execute_delete_password(username: &str, verbose: u8, entry: &Entry) {
+fn execute_delete_password(args: &Cli, entry: &Entry) {
     match entry.delete_password() {
-        Ok(()) => println!("(Password for user '{}' deleted)", username),
+        Ok(()) => println!("(Password for '{}@{}' deleted)", &args.user, &args.service),
         Err(Error::NoEntry) => {
-            eprintln!("(No password for user '{}' found)", username);
-            if verbose > 1 {
-                eprintln!("Error details: {:?}", Error::NoEntry);
-            }
+            eprintln!("(No password for '{}@{}' found)", &args.user, &args.service);
         }
         Err(err) => {
-            eprintln!("Couldn't delete password for user '{}': {}", username, err);
-            if verbose > 1 {
-                eprintln!("Error details: {:?}", err);
-            }
+            eprintln!(
+                "Couldn't delete password for '{}@{}': {:?}",
+                &args.user, &args.service, err
+            );
         }
     }
 }

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -135,7 +135,10 @@ impl CredentialBuilderApi for KeyutilsCredentialBuilder {
 
 fn decode_error(err: KeyError) -> ErrorCode {
     match err {
-        KeyError::KeyDoesNotExist | KeyError::AccessDenied => ErrorCode::NoEntry,
+        KeyError::KeyDoesNotExist
+        | KeyError::AccessDenied
+        | KeyError::KeyRevoked
+        | KeyError::KeyExpired => ErrorCode::NoEntry,
         KeyError::InvalidDescription => ErrorCode::Invalid(
             "description".to_string(),
             "rejected by platform".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,8 +251,9 @@ mod tests {
         entry
             .delete_password()
             .unwrap_or_else(|err| panic!("Can't delete password for {case}: {err:?}"));
+        let password = entry.get_password();
         assert!(
-            matches!(entry.get_password(), Err(Error::NoEntry)),
+            matches!(password, Err(Error::NoEntry)),
             "Read deleted password for {}",
             case
         );


### PR DESCRIPTION
While upgrading to the latest clap, the CLI was simplified to not have a verbose flag and always to show error details.