### PR TITLE
Incorporate secret service 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - introduce protection against the use of empty arguments
 
 ## Version 1.1.2
-- replace `structopt` with new, improved `clap` that incoporates all of the same functionality.
+- replace `structopt` with new, improved `clap` that incorporates all the same functionality.
 
 ## Version 1.1.1
 - no functional updates, just documentation improvements
@@ -47,7 +47,7 @@
 ## Version 0.10.0
 - ability to access named keychains in macos (nagasunilt)
 
-## Verion 0.9.0
+## Version 0.9.0
 - upgrade security-framework 0.3.0 -> 0.4.2
 - upgrade secret-service 1.0.0 -> 1.1.0 (updates hkdf dep, fixes error handling related to missing collection)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,16 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 edition = "2021"
 exclude = [".github/"]
 
 [features]
-default = ["linux-secret-service"]
-linux-secret-service = []
+default = ["linux-secret-service-rt-async-io-crypto-rust"]
+linux-secret-service-rt-async-io-crypto-rust = ["secret-service/rt-async-io-crypto-rust"]
+linux-secret-service-rt-tokio-crypto-rust = ["secret-service/rt-tokio-crypto-rust"]
+linux-secret-service-rt-async-io-crypto-openssl = ["secret-service/rt-async-io-crypto-openssl"]
+linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-openssl"]
 linux-keyutils = []
 
 [dependencies]
@@ -25,7 +28,7 @@ security-framework = "2.6"
 security-framework = "2.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-secret-service = "2.0"
+secret-service = { git = "https://github.com/hwchen/secret-service-rs.git", version = "3" }
 linux-keyutils = { version = "0.2", features = ["std"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -48,5 +48,5 @@ impl std::fmt::Debug for CredentialBuilder {
 /// Credential Builders must be Sync so they can be invoked from
 /// multiple threads simultaneously.  Although no one expects a
 /// Credential Builder to be passed from one thread to another,
-/// they are usually singletons, so making them Send should be easy.
+/// they are usually objects, so Send should be easy.
 pub type CredentialBuilder = dyn CredentialBuilderApi + Send + Sync;

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,10 @@ is not much of a burden on the platform-specific store providers.)
 /// Each variant of the `Error` enum provides a summary of the error.
 /// More details, if relevant, are contained in the associated value,
 /// which may be platform-specific.
+///
+/// Because future releases may add variants to this enum, clients should
+/// always be prepared for that.
+#[non_exhaustive]
 pub enum Error {
     /// This indicates runtime failure in the underlying
     /// platform storage system.  The details of the failure can

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -58,7 +58,7 @@ impl CredentialApi for KeyutilsCredential {
             .map_err(decode_error)?;
 
         // Directly re-link to the session keyring
-        // If a logout occured, it will only be linked to the
+        // If a logout occurred, it will only be linked to the
         // persistent keyring, and needs to be added again.
         self.session.link_key(key).map_err(decode_error)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ use macos as default;
 use windows as default;
 
 // Set the default keystore on each platform
-#[cfg(all(target_os = "linux", feature = "linux-secret-service"))]
+#[cfg(all(target_os = "linux", not(feature = "linux-keyutils")))]
 use crate::secret_service as default;
 
 pub mod credential;


### PR DESCRIPTION
This gets us to alpha.4 for keyring v2.  It has a some important tweaks relative to the last alpha:

1. It uses the new secret-service v3 (fixes #96).  Thanks to @Sytten for making me aware of the new service.  For now, the new version is only on github, so the new alpha can't be published to crates.io.
2. It removes the unsafe mutable static that was used to remember the default credential builder, instead using an RWLock which allows simultaneous credential creation.  Thanks to @landhb for suggesting a mutex here; this is an improvement on his suggestion.
3. It makes the `Error` enum explicitly non-exhaustive, so adding errors to accommodate new credential stores won't be an API-breaking change for clients.
4. It fixes #84 by unlocking items if needed in secret-service.  Thanks to @jkhsjdhjs for this fix.

Once secret-service v3 gets published this will get published as an RC and I will go to work on updating the docs.

