### PR TITLE
Add service-level search to secret-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Version 2.0
-- Introduce traits for pluggable store implementations.
-- Add a `mock` store.
+- Introduce traits for pluggable credential-store implementations.
+- Add a `mock` credential store for easy cross-platform client testing.
+- Add optional service-level search in secret-service.
+- Add the kernel keyring as a linux credential store.
+
+## Version 1.2.1
+- password length was not validated correctly on Windows (#85)
 
 ## Version 1.2
 - introduce protection against the use of empty arguments

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,14 @@ edition = "2021"
 exclude = [".github/"]
 
 [features]
-default = ["linux-default-secret-service-rt-async-io-crypto-rust"]
-linux-default-secret-service-rt-async-io-crypto-rust = ["secret-service/rt-async-io-crypto-rust"]
-linux-default-secret-service-rt-tokio-crypto-rust = ["secret-service/rt-tokio-crypto-rust"]
-linux-default-secret-service-rt-async-io-crypto-openssl = ["secret-service/rt-async-io-crypto-openssl"]
-linux-default-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-openssl"]
+default = ["linux-secret-service"]
+linux-secret-service = ["secret-service"]
+# TODO: change for v3
+#linux-secret-service = ["linux-secret-service-rt-async-io-crypto-rust"]
+#linux-secret-service-rt-async-io-crypto-rust = ["secret-service/rt-async-io-crypto-rust"]
+#linux-secret-service-rt-tokio-crypto-rust = ["secret-service/rt-tokio-crypto-rust"]
+#linux-secret-service-rt-async-io-crypto-openssl = ["secret-service/rt-async-io-crypto-openssl"]
+#linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-openssl"]
 linux-no-secret-service = ["linux-default-keyutils"]
 linux-default-keyutils = []
 
@@ -29,7 +32,9 @@ security-framework = "2.6"
 security-framework = "2.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-secret-service = { git = "https://github.com/hwchen/secret-service-rs.git", version = "3", optional = true }
+# TODO: switch when v3 is released
+secret-service = { version = "2", optional = true }
+#secret-service = { git = "https://github.com/hwchen/secret-service-rs.git", version = "3", optional = true }
 linux-keyutils = { version = "0.2", features = ["std"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "2.0.0-alpha.4"
+version = "2.0.0-beta.1"
 edition = "2021"
 exclude = [".github/"]
 

--- a/README.md
+++ b/README.md
@@ -47,21 +47,23 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ## Errors
 
-The `get_password`, `set_password` and `delete_password` functions return a `Result` which, if the operation was unsuccessful, can yield a `keyring::Error` with a platform-independent code that describes the error.
+Creating and operating on entries can yield a `keyring::Error` which provides both a platform-independent code that classifies the error and, where available, underlying platform errors and/or more information about what went wrong.
 
 ## Examples
 
 The keychain-rs project contains a sample application (`cli`) and a sample library (`ios`).
 
-The application is a command-line interface to the keychain.  This can be a great way to explore how the library is used, and it allows experimentation with the use of different service names, usernames, and targets.  When run in "singly verbose" mode (-v), it outputs the retrieved credentials on each `get` run.  When run in "doubly verbose" mode (-vv), it also outputs any errors returned.  This can be a great way to see which errors result from which conditions on each platform.
+The application is a command-line interface to the keyring.  This can be a great way to explore how the library is used, and it allows experimentation with the use of different service names, usernames, and targets.  When run in "singly verbose" mode (-v), it outputs the retrieved credentials on each `get` run.  When run in "doubly verbose" mode (-vv), it also outputs any errors returned.  This can be a great way to see which errors result from which conditions on each platform.
 
-The sample library is a full exercise of all the iOS functionality; it's meant to be loaded into an iOS test harness such as the one found in [this project](https://github.com/brotskydotcom/rust-on-ios). While the library can be compiled and linked to on macOS as well, doing so doesn't provide any advantages over using standard Rust tests.
+The sample library is a full exercise of all the iOS functionality; it's meant to be loaded into an iOS test harness such as the one found in [this project](https://github.com/brotskydotcom/rust-on-ios). While the library can be compiled and linked to on macOS as well, doing so doesn't provide any advantages over the standard macOS tests.
 
-## Known Issues
+## Client Testing
 
-Because credentials identified with empty service, user, or target names are handled inconsistently at the platform layer, the library had inconsistent (and arguably buggy - see [#86](https://github.com/hwchen/keyring-rs/issues/86)) behavior in this case.  As of version 1.2, this inconsistency was eliminated by having the library always fail on access when using credentials created with empty strings via `new` or `new_with_target`.  The prior platform-specific behavior can still be accessed, however, by using `new_with_credential` to produce the same credential that would have been produced before the change.
+This crate comes with a "mock" credential store that can be used by clients who want to test without accessing the native platform store.  The mock store is cross-platform and allows mocking errors as well as successes.
 
-A better way to handle empty strings (and other problematic argument values) would be to allow `Entry` creation to fail gracefully on arguments that are known not to work on a given platform.  That would be a breaking API change, however, so it will have to wait until the next major version.
+## Extensibility
+
+This crate comes with built-in support for the keychain on Mac, the credential manager on Windows, and both secret-service and the kernel keyring on Linux.  But it's also designed to allow clients to "bring their own credential stores" by providing traits that clients can implement.  See the [developer docs](https://docs.rs/keyring/latest/keyring/) for details.
 
 ## Dev Notes
 
@@ -71,6 +73,8 @@ A better way to handle empty strings (and other problematic argument values) wou
 ### Headless Linux
 
 If you are trying to use keyring on a headless linux box, be aware that there are known issues with getting dbus and secret-service and the gnome keyring to work properly in headless environments.  For a quick workaround, look at how this project's [CI workflow](https://github.com/hwchen/keyring-rs/blob/master/.github/workflows/build.yaml) uses the [linux-test.sh](https://github.com/hwchen/keyring-rs/blob/master/linux-test.sh) script; a similar solution is also documented in the [Python Keyring docs](https://pypi.org/project/keyring/) (search for "Using Keyring on headless Linux systems").  For an excellent treatment of all the headless dbus issues, see [this answer on ServerFault](https://serverfault.com/a/906224/79617).
+
+Note that you can build this crate without secret-service support; this makes the Linux keyring (which works normally on headless linux) the default credential store on Linux platforms.
 
 ## License
 
@@ -82,16 +86,22 @@ Licensed under either of
 at your option.
 
 ## Contributors
+
 Thanks to the following for helping make this library better, whether through contributing code, discussion, or bug reports!
 
+- @Alexei-Barnes
 - @bhkaminski
 - @brotskydotcom
+- @complexspaces
 - @dario23
 - @dten
 - @gondolyr
+- @hwchen
 - @jasikpark
+- @jkhsjdhjs
 - @jonathanmorley
 - @jyuch
+- @landhb
 - @lexxvir
 - @MaikKlein
 - @Phrohdoh
@@ -99,6 +109,9 @@ Thanks to the following for helping make this library better, whether through co
 - @samuela
 - @stankec
 - @steveatinfincia
+- @Sytten
+
+If you should be on this list, but don't find yourself, please contact @brotskydotcom.
 
 ### Contribution
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Keyring-rs
-[![CI](https://github.com/hwchen/keyring-rs/workflows/ci/badge.svg)](https://github.com/hwchen/keyring-rs/actions?query=workflow%3Aci)
+[![CI](https://github.com/hwchen/keyring-rs/actions/workflows/build.yaml/badge.svg)](https://github.com/hwchen/keyring-rs/actions?query=workflow%3Abuild)
 [![Crates.io](https://img.shields.io/crates/v/keyring.svg?style=flat-square)](https://crates.io/crates/keyring)
 [![API Documentation on docs.rs](https://docs.rs/keyring/badge.svg)](https://docs.rs/keyring)
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -59,16 +59,16 @@ fn execute_args(args: &Cli) {
     match &args.command {
         Command::Set {
             password: Some(password),
-        } => execute_set_password(&args, &entry, password),
+        } => execute_set_password(args, &entry, password),
         Command::Set { password: None } => {
             if let Ok(password) = prompt_password("Password: ") {
-                execute_set_password(&args, &entry, &password)
+                execute_set_password(args, &entry, &password)
             } else {
                 eprintln!("(Failed to read password, so none set.)")
             }
         }
-        Command::Get => execute_get_password(&args, &entry),
-        Command::Delete => execute_delete_password(&args, &entry),
+        Command::Get => execute_get_password(args, &entry),
+        Command::Delete => execute_delete_password(args, &entry),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ is not much of a burden on the platform-specific store providers.)
 
  */
 
+use crate::Credential;
+
 #[derive(Debug)]
 /// Each variant of the `Error` enum provides a summary of the error.
 /// More details, if relevant, are contained in the associated value,
@@ -49,6 +51,9 @@ pub enum Error {
     /// attached value gives the name of the attribute
     /// and the reason it's invalid.
     Invalid(String, String),
+    /// This indicates that there is more than one credential found in the store
+    /// that matches the entry.  Its value is a vector of the matching credentials.
+    Ambiguous(Vec<Box<Credential>>),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -69,6 +74,14 @@ impl std::fmt::Display for Error {
             ),
             Error::Invalid(attr, reason) => {
                 write!(f, "Attribute {} is invalid: {}", attr, reason)
+            }
+            Error::Ambiguous(items) => {
+                write!(
+                    f,
+                    "Entry is matched by {} credendials: {:?}",
+                    items.len(),
+                    items
+                )
             }
         }
     }

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
-use secret_service::blocking::{Collection, SecretService};
-pub use secret_service::{EncryptionType, Error, Item};
+// TODO: change to blocking for v3
+use secret_service::{Collection, Item, SecretService};
+// use secret_service::blocking::{Collection, Item, SecretService};
+pub use secret_service::{EncryptionType, Error};
 
 use super::credential::{Credential, CredentialApi, CredentialBuilder, CredentialBuilderApi};
 use super::error::{decode_password, Error as ErrorCode, Result};
@@ -12,6 +14,7 @@ use super::error::{decode_password, Error as ErrorCode, Result};
 /// graphical editors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SsCredential {
+    pub search_all: bool,
     pub collection: String,
     pub attributes: HashMap<String, String>,
     pub label: String,
@@ -19,12 +22,14 @@ pub struct SsCredential {
 
 impl CredentialApi for SsCredential {
     fn set_password(&self, password: &str) -> Result<()> {
-        let ss = SecretService::connect(EncryptionType::Dh).map_err(platform_failure)?;
+        // TODO: change to connect for v3
+        let ss = SecretService::new(EncryptionType::Dh).map_err(platform_failure)?;
+        // let ss = SecretService::connect(EncryptionType::Dh).map_err(platform_failure)?;
         let collection = self.get_collection(&ss)?;
         collection
             .create_item(
                 self.label.as_str(),
-                self.attributes(),
+                self.all_attributes(),
                 password.as_bytes(),
                 true, // replace
                 "text/plain",
@@ -34,31 +39,18 @@ impl CredentialApi for SsCredential {
     }
 
     fn get_password(&self) -> Result<String> {
-        let ss = SecretService::connect(EncryptionType::Dh).map_err(decode_error)?;
-        let collection = self.get_collection(&ss)?;
-        let search = collection
-            .search_items(self.attributes())
-            .map_err(decode_error)?;
-        let item = search.first().ok_or(ErrorCode::NoEntry)?;
-        if item.is_locked().map_err(decode_error)? {
-            item.unlock().map_err(decode_error)?;
+        fn get_password(item: &Item) -> Result<String> {
+            let bytes = item.get_secret().map_err(decode_error)?;
+            decode_password(bytes)
         }
-        let bytes = item.get_secret().map_err(decode_error)?;
-        decode_password(bytes)
+        self.map_item(get_password)
     }
 
     fn delete_password(&self) -> Result<()> {
-        let ss = SecretService::connect(EncryptionType::Dh).map_err(decode_error)?;
-        let collection = self.get_collection(&ss)?;
-        let search = collection
-            .search_items(self.attributes())
-            .map_err(decode_error)?;
-        let item = search.first().ok_or(ErrorCode::NoEntry)?;
-        if item.is_locked().map_err(decode_error)? {
-            item.unlock().map_err(decode_error)?;
+        fn delete_item(item: &Item) -> Result<()> {
+            item.delete().map_err(decode_error)
         }
-        item.delete().map_err(decode_error)?;
-        Ok(())
+        self.map_item(delete_item)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -67,24 +59,99 @@ impl CredentialApi for SsCredential {
 }
 
 impl SsCredential {
-    /// Construct a credential from the underlying platform credential
-    pub fn get_credential(&self) -> Result<Self> {
-        let mut result = self.clone();
-        let ss = SecretService::connect(EncryptionType::Dh).map_err(decode_error)?;
-        let collection = self.get_collection(&ss)?;
-        let search = collection
-            .search_items(self.attributes())
-            .map_err(decode_error)?;
-        let item = search.first().ok_or(ErrorCode::NoEntry)?;
-        if item.is_locked().map_err(decode_error)? {
-            item.unlock().map_err(decode_error)?;
+    /// Create a credential for the given entries.
+    ///
+    /// See the top-level module docs for conventions used.
+    pub fn new_with_target(
+        search_all: bool,
+        target: Option<&str>,
+        service: &str,
+        user: &str,
+    ) -> Result<Self> {
+        if let Some("") = target {
+            return Err(ErrorCode::Invalid(
+                "target".to_string(),
+                "cannot be empty".to_string(),
+            ));
         }
+        let target = target.unwrap_or("default");
+        let mut attributes = HashMap::from([
+            ("service".to_string(), service.to_string()),
+            ("username".to_string(), user.to_string()),
+            ("application".to_string(), "rust-keyring".to_string()),
+        ]);
+        if search_all {
+            attributes.insert("target".to_string(), target.to_string());
+        }
+        Ok(Self {
+            search_all,
+            collection: target.to_string(),
+            attributes,
+            label: format!(
+                "keyring-rs v{} for target '{}', service '{}', user '{}'",
+                env!("CARGO_PKG_VERSION"),
+                target,
+                service,
+                user
+            ),
+        })
+    }
+
+    /// Construct a credential from the underlying platform credential, if there is exactly one.
+    pub fn get_credential(&self) -> Result<Self> {
+        self.map_item(|i: &Item| self.clone_from_item(i))
+    }
+
+    /// Map the matching item for this credential, if there is exactly one.
+    fn map_item<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&Item) -> Result<T>,
+        T: Sized,
+    {
+        // TODO: change to connect for v3
+        let ss = SecretService::new(EncryptionType::Dh).map_err(platform_failure)?;
+        // let ss = SecretService::connect(EncryptionType::Dh).map_err(platform_failure)?;
+        let map_only_item = |search: &Vec<Item>| -> Result<T> {
+            let item = match search.len() {
+                0 => return Err(ErrorCode::NoEntry),
+                1 => &search[0],
+                _ => {
+                    let mut creds: Vec<Box<Credential>> = vec![];
+                    for item in search.iter() {
+                        let cred = self.clone_from_item(item)?;
+                        creds.push(Box::new(cred))
+                    }
+                    return Err(ErrorCode::Ambiguous(creds));
+                }
+            };
+            if item.is_locked().map_err(decode_error)? {
+                item.unlock().map_err(decode_error)?;
+            }
+            f(item)
+        };
+        if self.search_all {
+            // TODO: change to locked/unlocked return val in v3
+            let attributes: Vec<(&str, &str)> = self.search_attributes().into_iter().collect();
+            let search = ss.search_items(attributes).map_err(decode_error)?;
+            map_only_item(&search)
+        } else {
+            let collection = self.get_collection(&ss)?;
+            let search = collection
+                .search_items(self.search_attributes())
+                .map_err(decode_error)?;
+            map_only_item(&search)
+        }
+    }
+
+    // Create a credential from an underlying item that matches it
+    fn clone_from_item(&self, item: &Item) -> Result<Self> {
+        let mut result = self.clone();
         result.attributes = item.get_attributes().map_err(decode_error)?;
         result.label = item.get_label().map_err(decode_error)?;
         Ok(result)
     }
 
-    /// Find the secret service collection for the map
+    /// Find the secret service collection that will contain this item
     fn get_collection<'a>(&self, ss: &'a SecretService) -> Result<Collection<'a>> {
         let collection = ss
             .get_collection_by_alias(self.collection.as_str())
@@ -99,81 +166,41 @@ impl SsCredential {
     /// of the credential much easier.  But since the secret service expects
     /// a map from &str to &str, we have this utility to transform the
     /// credential's map into one of the right form.
-    fn attributes(&self) -> HashMap<&str, &str> {
+    fn all_attributes(&self) -> HashMap<&str, &str> {
         self.attributes
             .iter()
             .map(|(k, v)| (k.as_str(), v.as_str()))
             .collect()
     }
 
-    /// Create a credential for the given entries.
-    ///
-    /// See the top-level module docs for conventions used.
-    pub fn new_with_target(target: Option<&str>, service: &str, user: &str) -> Result<Self> {
-        if let Some("") = target {
-            return Err(ErrorCode::Invalid(
-                "target".to_string(),
-                "cannot be empty".to_string(),
-            ));
+    /// Similar to all_attributes, but this just selects the ones we search on
+    fn search_attributes(&self) -> HashMap<&str, &str> {
+        let mut result: HashMap<&str, &str> = HashMap::new();
+        result.insert("service", self.attributes["service"].as_str());
+        result.insert("username", self.attributes["username"].as_str());
+        if self.search_all {
+            result.insert("target", self.attributes["target"].as_str());
         }
-        let target = target.unwrap_or("default");
-        Ok(Self {
-            collection: target.to_string(),
-            attributes: HashMap::from([
-                ("service".to_string(), service.to_string()),
-                ("username".to_string(), user.to_string()),
-                ("application".to_string(), "rust-keyring".to_string()),
-            ]),
-            label: format!(
-                "keyring-rs v{} for target '{}', service '{}', user '{}'",
-                env!("CARGO_PKG_VERSION"),
-                target,
-                service,
-                user
-            ),
-        })
+        result
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SsCredentialBuilder {
-    name: String,
-    target: TargetUsage,
-    search: SearchType,
-}
-
-#[derive(Debug, Clone)]
-pub enum TargetUsage {
-    CollectionOnly,
-    AttributeOnly,
-    CollectionAndAttribute,
-}
-
-#[derive(Debug, Clone)]
-pub enum SearchType {
-    Collection,
-    Everywhere(TargetAttributeHandling),
-}
-
-#[derive(Debug, Clone)]
-pub enum TargetAttributeHandling {
-    Prefer,
-    Require,
-    DontCare,
+    search_all: bool,
 }
 
 pub fn default_credential_builder() -> Box<CredentialBuilder> {
-    Box::new(SsCredentialBuilder {
-        name: "SsDefault".to_string(),
-        target: TargetUsage::CollectionOnly,
-        search: SearchType::Collection,
-    })
+    Box::new(SsCredentialBuilder::new_with_options(true))
 }
 
 impl CredentialBuilderApi for SsCredentialBuilder {
     fn build(&self, target: Option<&str>, service: &str, user: &str) -> Result<Box<Credential>> {
         Ok(Box::new(SsCredential::new_with_target(
-            target, service, user,
+            self.search_all,
+            target,
+            service,
+            user,
         )?))
     }
 
@@ -183,24 +210,8 @@ impl CredentialBuilderApi for SsCredentialBuilder {
 }
 
 impl SsCredentialBuilder {
-    pub fn new_with_options(name: &str, target: &TargetUsage, search: &SearchType) -> Self {
-        Self {
-            name: name.to_string(),
-            target: target.clone(),
-            search: search.clone(),
-        }
-    }
-
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    pub fn target(&self) -> TargetUsage {
-        self.target.clone()
-    }
-
-    pub fn search(&self) -> SearchType {
-        self.search.clone()
+    pub fn new_with_options(search_all: bool) -> Self {
+        Self { search_all }
     }
 }
 
@@ -213,7 +224,8 @@ fn decode_error(err: Error) -> ErrorCode {
         Error::Locked => no_access(err),
         Error::NoResult => no_access(err),
         Error::Prompt => no_access(err),
-        Error::Unavailable => platform_failure(err),
+        // TODO: uncomment for v3
+        // Error::Unavailable => platform_failure(err),
         _ => platform_failure(err),
     }
 }
@@ -232,17 +244,20 @@ fn wrap(err: Error) -> Box<dyn std::error::Error + Send + Sync> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{tests::generate_random_string, Entry, Error};
+    use crate::{tests::generate_random_string, Entry, Error, Result};
 
     use super::SsCredential;
 
     fn entry_new(service: &str, user: &str) -> Entry {
-        crate::tests::entry_from_constructor(SsCredential::new_with_target, service, user)
+        fn new_false(target: Option<&str>, service: &str, user: &str) -> Result<SsCredential> {
+            SsCredential::new_with_target(false, target, service, user)
+        }
+        crate::tests::entry_from_constructor(new_false, service, user)
     }
 
     #[test]
     fn test_invalid_parameter() {
-        let credential = SsCredential::new_with_target(Some(""), "service", "user");
+        let credential = SsCredential::new_with_target(false, Some(""), "service", "user");
         assert!(
             matches!(credential, Err(Error::Invalid(_, _))),
             "Created entry with empty target"

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -135,10 +135,39 @@ impl SsCredential {
     }
 }
 
-pub struct SsCredentialBuilder {}
+#[derive(Debug)]
+pub struct SsCredentialBuilder {
+    name: String,
+    target: TargetUsage,
+    search: SearchType,
+}
+
+#[derive(Debug, Clone)]
+pub enum TargetUsage {
+    CollectionOnly,
+    AttributeOnly,
+    CollectionAndAttribute,
+}
+
+#[derive(Debug, Clone)]
+pub enum SearchType {
+    Collection,
+    Everywhere(TargetAttributeHandling),
+}
+
+#[derive(Debug, Clone)]
+pub enum TargetAttributeHandling {
+    Prefer,
+    Require,
+    DontCare,
+}
 
 pub fn default_credential_builder() -> Box<CredentialBuilder> {
-    Box::new(SsCredentialBuilder {})
+    Box::new(SsCredentialBuilder {
+        name: "SsDefault".to_string(),
+        target: TargetUsage::CollectionOnly,
+        search: SearchType::Collection,
+    })
 }
 
 impl CredentialBuilderApi for SsCredentialBuilder {
@@ -150,6 +179,28 @@ impl CredentialBuilderApi for SsCredentialBuilder {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+impl SsCredentialBuilder {
+    pub fn new_with_options(name: &str, target: &TargetUsage, search: &SearchType) -> Self {
+        Self {
+            name: name.to_string(),
+            target: target.clone(),
+            search: search.clone(),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn target(&self) -> TargetUsage {
+        self.target.clone()
+    }
+
+    pub fn search(&self) -> SearchType {
+        self.search.clone()
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -181,9 +181,7 @@ impl WinCredential {
                 // Now we can apply the passed extractor function to the credential.
                 let result = f(&w_credential);
                 // Finally, we free the allocated credential.
-                unsafe {
-                    CredFree(p_credential as *mut _);
-                }
+                unsafe { CredFree(p_credential as *mut _) };
                 result
             }
         }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -14,6 +14,7 @@ fn test_missing_entry() {
 }
 
 #[test]
+#[cfg(all(target_os = "linux", not(feature = "linux-default-keyutils")))]
 fn test_empty_password() {
     let name = generate_random_string();
     let entry = Entry::new(&name, &name).expect("Can't create entry");


### PR DESCRIPTION
This introduces one option in the secret-service credential store builder: a boolean `search_all` which means to search for credentials in all collections (i.e., use service-level search).  When you turn on `search_all` in the builder, it causes all the credentials to include a `target` attribute (as well as using the target for the collection name in which the credential is created), and it always searches for credentials at service level *including* the target attribute.  This means:

* if `search_all` is off (the default), then we are completely compatible with v1 credentials and we have to do the explicit check for a locked credential on get and delete.
* if `search_all` is on, then we will never see any v1 or `search_all`=off credentials at all (because none have a target attribute).

Note that v1 and `search_all`=off *will* find credentials built with `search_all`=on (because they ignore the target attribute).  In addition, because of the way the secret service works, doing a v1 or `search_all`=off set-password call will remove the `target` attribute from an existing credential with the same service and user.

Thus, to write a v2 client that always uses service-level search but is compatible with non-service-level search clients, the service-level search client should always delete any existing non-target entry with the same user and service before setting a password.  This is very easy to do because you can use two credential stores side-by-side in the same v2 client.

Fixes #84.