### PR TITLE
Rework the secret-service to always use collection search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Version 2.0
 - Introduce traits for pluggable credential-store implementations.
 - Add a `mock` credential store for easy cross-platform client testing.
-- Add optional service-level search in secret-service.
+- Use service-level search in secret-service.
+- Allow creation of new collections in secret-service.
 - Add the kernel keyring as a linux credential store.
 
 ## Version 1.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition = "2021"
 exclude = [".github/"]
 

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -12,16 +12,25 @@ use super::error::{decode_password, Error as ErrorCode, Result};
 /// graphical editors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SsCredential {
-    pub search_all: bool,
-    pub collection: String,
     pub attributes: HashMap<String, String>,
     pub label: String,
+    target: Option<String>,
 }
 
 impl CredentialApi for SsCredential {
     fn set_password(&self, password: &str) -> Result<()> {
         let ss = SecretService::connect(EncryptionType::Dh).map_err(platform_failure)?;
-        let collection = self.get_collection(&ss)?;
+        let set_password = |item: &Item| -> Result<()> {
+            item.set_secret(password.as_bytes(), "text/plain")
+                .map_err(decode_error)
+        };
+        match self.map_matching_items(set_password, true) {
+            Ok(_) => return Ok(()),
+            Err(ErrorCode::NoEntry) => {}
+            Err(err) => return Err(err),
+        }
+        let name = self.target.as_ref().ok_or_else(empty_target)?;
+        let collection = get_collection(&ss, name).or_else(|_| create_collection(&ss, name))?;
         collection
             .create_item(
                 self.label.as_str(),
@@ -35,18 +44,13 @@ impl CredentialApi for SsCredential {
     }
 
     fn get_password(&self) -> Result<String> {
-        fn get_password(item: &Item) -> Result<String> {
-            let bytes = item.get_secret().map_err(decode_error)?;
-            decode_password(bytes)
-        }
-        self.map_item(get_password)
+        let passwords: Vec<String> = self.map_matching_items(get_item_password, true)?;
+        Ok(passwords[0].clone())
     }
 
     fn delete_password(&self) -> Result<()> {
-        fn delete_item(item: &Item) -> Result<()> {
-            item.delete().map_err(decode_error)
-        }
-        self.map_item(delete_item)
+        self.map_matching_items(delete_item, true)?;
+        Ok(())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -55,127 +59,97 @@ impl CredentialApi for SsCredential {
 }
 
 impl SsCredential {
-    /// Create a credential for the given entries.
-    ///
-    /// See the top-level module docs for conventions used.
-    pub fn new_with_target(
-        search_all: bool,
-        target: Option<&str>,
-        service: &str,
-        user: &str,
-    ) -> Result<Self> {
+    /// Create a credential for the given target, service, and user.
+    pub fn new_with_target(target: Option<&str>, service: &str, user: &str) -> Result<Self> {
         if let Some("") = target {
-            return Err(ErrorCode::Invalid(
-                "target".to_string(),
-                "cannot be empty".to_string(),
-            ));
+            return Err(empty_target());
         }
         let target = target.unwrap_or("default");
-        let mut attributes = HashMap::from([
+        let attributes = HashMap::from([
             ("service".to_string(), service.to_string()),
             ("username".to_string(), user.to_string()),
+            ("target".to_string(), target.to_string()),
             ("application".to_string(), "rust-keyring".to_string()),
         ]);
-        if search_all {
-            attributes.insert("target".to_string(), target.to_string());
-        }
         Ok(Self {
-            search_all,
-            collection: target.to_string(),
             attributes,
             label: format!(
-                "keyring-rs v{} for target '{}', service '{}', user '{}'",
+                "keyring-rs v{} for target '{target}', service '{service}', user '{user}'",
                 env!("CARGO_PKG_VERSION"),
-                target,
-                service,
-                user
             ),
+            target: Some(target.to_string()),
         })
     }
 
-    /// Construct a credential from the underlying platform credential, if there is exactly one.
-    pub fn get_credential(&self) -> Result<Self> {
-        self.map_item(|i: &Item| self.clone_from_item(i))
+    // Create a credential from an underlying item that matches it
+    fn new_from_item(item: &Item) -> Result<Self> {
+        let attributes = item.get_attributes().map_err(decode_error)?;
+        let target = attributes.get("target").cloned();
+        Ok(Self {
+            attributes,
+            label: item.get_label().map_err(decode_error)?,
+            target,
+        })
     }
 
-    /// Map the matching item for this credential, if there is exactly one.
-    fn map_item<F, T>(&self, f: F) -> Result<T>
+    /// Construct a credential from the underlying Item, if there is exactly one.
+    pub fn get_credential(&self) -> Result<Self> {
+        let credentials = self.map_matching_items(Self::new_from_item, true)?;
+        Ok(credentials[0].clone())
+    }
+
+    /// If there are multiple matching Items, get all of their passwords.
+    /// (This is useful if get_password returns an `Ambiguous` error.)
+    pub fn get_all_passwords(&self) -> Result<Vec<String>> {
+        self.map_matching_items(get_item_password, true)
+    }
+
+    /// If there are multiple matching Items, delete all of them.
+    /// (This is useful if get_password returns an `Ambiguous` error.)
+    pub fn delete_all_passwords(&self) -> Result<()> {
+        self.map_matching_items(delete_item, true)?;
+        Ok(())
+    }
+
+    /// Map a function over all of the items matching this credential.
+    /// Items are unlocked before the function is applied.
+    /// If `require_unique` is true, and there are no matching items, then
+    /// a `NoEntry` error is returned.
+    /// If `require_unique` is true, and there is more than one matching item,
+    /// then an `Ambiguous` error is returned with a vector of matching credentials.
+    fn map_matching_items<F, T>(&self, f: F, require_unique: bool) -> Result<Vec<T>>
     where
-        F: FnOnce(&Item) -> Result<T>,
+        F: Fn(&Item) -> Result<T>,
         T: Sized,
     {
         let ss = SecretService::connect(EncryptionType::Dh).map_err(platform_failure)?;
-        enum YesNoMaybe {
-            Yes,
-            No,
-            Maybe,
-        }
-        let map_only_item = |search: &Vec<Item>, unlock: YesNoMaybe| -> Result<T> {
-            let item = match search.len() {
-                0 => return Err(ErrorCode::NoEntry),
-                1 => &search[0],
-                _ => {
-                    let mut creds: Vec<Box<Credential>> = vec![];
-                    for item in search.iter() {
-                        let cred = self.clone_from_item(item)?;
-                        creds.push(Box::new(cred))
-                    }
-                    return Err(ErrorCode::Ambiguous(creds));
+        let attributes: HashMap<&str, &str> = self.search_attributes().into_iter().collect();
+        let search = ss.search_items(attributes).map_err(decode_error)?;
+        let target = self.target.as_ref().ok_or_else(empty_target)?;
+        let unlocked = matching_items(&search.unlocked, target)?;
+        let locked = matching_items(&search.locked, target)?;
+        if require_unique {
+            let count = locked.len() + unlocked.len();
+            if count == 0 {
+                return Err(ErrorCode::NoEntry);
+            } else if count > 1 {
+                let mut creds: Vec<Box<Credential>> = vec![];
+                for item in locked.into_iter().chain(unlocked.into_iter()) {
+                    let cred = Self::new_from_item(item)?;
+                    creds.push(Box::new(cred))
                 }
-            };
-            match unlock {
-                YesNoMaybe::Yes => item.unlock().map_err(decode_error)?,
-                YesNoMaybe::No => {}
-                YesNoMaybe::Maybe => {
-                    if item.is_locked().map_err(decode_error)? {
-                        item.unlock().map_err(decode_error)?;
-                    }
-                }
+                return Err(ErrorCode::Ambiguous(creds));
             }
-            f(item)
-        };
-        if self.search_all {
-            let attributes: HashMap<&str, &str> = self.search_attributes().into_iter().collect();
-            let search = ss.search_items(attributes).map_err(decode_error)?;
-            if search.locked.is_empty() {
-                map_only_item(&search.unlocked, YesNoMaybe::No)
-            } else if search.unlocked.is_empty() {
-                map_only_item(&search.locked, YesNoMaybe::Yes)
-            } else {
-                let all = search
-                    .locked
-                    .into_iter()
-                    .chain(search.unlocked.into_iter())
-                    .collect();
-                map_only_item(&all, YesNoMaybe::Maybe)
-            }
-        } else {
-            let collection = self.get_collection(&ss)?;
-            let search = collection
-                .search_items(self.search_attributes())
-                .map_err(decode_error)?;
-            map_only_item(&search, YesNoMaybe::Maybe)
         }
-    }
-
-    // Create a credential from an underlying item that matches it
-    fn clone_from_item(&self, item: &Item) -> Result<Self> {
-        let mut result = self.clone();
-        result.attributes = item.get_attributes().map_err(decode_error)?;
-        result.search_all = result.attributes.get("target").is_some();
-        result.label = item.get_label().map_err(decode_error)?;
-        Ok(result)
-    }
-
-    /// Find the secret service collection that will contain this item
-    fn get_collection<'a>(&self, ss: &'a SecretService) -> Result<Collection<'a>> {
-        let collection = ss
-            .get_collection_by_alias(self.collection.as_str())
-            .map_err(decode_error)?;
-        if collection.is_locked().map_err(decode_error)? {
-            collection.unlock().map_err(decode_error)?;
+        let mut results: Vec<T> = vec![];
+        for item in unlocked.into_iter() {
+            results.push(f(item)?);
         }
-        Ok(collection)
+        for item in locked.into_iter() {
+            item.unlock().map_err(decode_error)?;
+            results.push(f(item)?);
+        }
+        Ok(results)
     }
 
     /// Using strings in the credential map makes managing the lifetime
@@ -194,29 +168,21 @@ impl SsCredential {
         let mut result: HashMap<&str, &str> = HashMap::new();
         result.insert("service", self.attributes["service"].as_str());
         result.insert("username", self.attributes["username"].as_str());
-        if self.search_all {
-            result.insert("target", self.attributes["target"].as_str());
-        }
         result
     }
 }
 
 #[derive(Debug, Default)]
-pub struct SsCredentialBuilder {
-    search_all: bool,
-}
+pub struct SsCredentialBuilder {}
 
 pub fn default_credential_builder() -> Box<CredentialBuilder> {
-    Box::new(SsCredentialBuilder::new_with_options(true))
+    Box::new(SsCredentialBuilder {})
 }
 
 impl CredentialBuilderApi for SsCredentialBuilder {
     fn build(&self, target: Option<&str>, service: &str, user: &str) -> Result<Box<Credential>> {
         Ok(Box::new(SsCredential::new_with_target(
-            self.search_all,
-            target,
-            service,
-            user,
+            target, service, user,
         )?))
     }
 
@@ -225,12 +191,50 @@ impl CredentialBuilderApi for SsCredentialBuilder {
     }
 }
 
-impl SsCredentialBuilder {
-    pub fn new_with_options(search_all: bool) -> Self {
-        Self { search_all }
+//
+// Secret Service utilities
+//
+/// Find the secret service collection that should contain this item
+fn get_collection<'a>(ss: &'a SecretService, name: &str) -> Result<Collection<'a>> {
+    let collection = ss.get_collection_by_alias(name).map_err(decode_error)?;
+    if collection.is_locked().map_err(decode_error)? {
+        collection.unlock().map_err(decode_error)?;
     }
+    Ok(collection)
 }
 
+/// Create the secret service collection that will contain this credential
+fn create_collection<'a>(ss: &'a SecretService, name: &str) -> Result<Collection<'a>> {
+    let collection = ss
+        .create_collection("keyring collection '{name}'", name)
+        .map_err(decode_error)?;
+    Ok(collection)
+}
+
+fn get_item_password(item: &Item) -> Result<String> {
+    let bytes = item.get_secret().map_err(decode_error)?;
+    decode_password(bytes)
+}
+
+fn delete_item(item: &Item) -> Result<()> {
+    item.delete().map_err(decode_error)
+}
+
+fn matching_items<'a>(source: &'a [Item<'a>], target: &str) -> Result<Vec<&'a Item<'a>>> {
+    let mut result: Vec<&'a Item<'a>> = vec![];
+    for i in source.iter() {
+        match i.get_attributes().map_err(decode_error)?.get("target") {
+            None => result.push(i),
+            Some(item_target) if target.eq(item_target) => result.push(i),
+            _ => {}
+        }
+    }
+    Ok(result)
+}
+
+//
+// Error utilities
+//
 fn decode_error(err: Error) -> ErrorCode {
     match err {
         Error::Crypto(_) => platform_failure(err),
@@ -243,6 +247,10 @@ fn decode_error(err: Error) -> ErrorCode {
         Error::Unavailable => platform_failure(err),
         _ => platform_failure(err),
     }
+}
+
+fn empty_target() -> ErrorCode {
+    ErrorCode::Invalid("target".to_string(), "cannot be empty".to_string())
 }
 
 fn platform_failure(err: Error) -> ErrorCode {
@@ -259,27 +267,17 @@ fn wrap(err: Error) -> Box<dyn std::error::Error + Send + Sync> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{tests::generate_random_string, Entry, Error, Result};
+    use crate::{tests::generate_random_string, Entry, Error};
 
     use super::SsCredential;
 
-    fn entry_new_false(service: &str, user: &str) -> Entry {
-        fn new_false(target: Option<&str>, service: &str, user: &str) -> Result<SsCredential> {
-            SsCredential::new_with_target(false, target, service, user)
-        }
-        crate::tests::entry_from_constructor(new_false, service, user)
-    }
-
-    fn entry_new_true(service: &str, user: &str) -> Entry {
-        fn new_true(target: Option<&str>, service: &str, user: &str) -> Result<SsCredential> {
-            SsCredential::new_with_target(true, target, service, user)
-        }
-        crate::tests::entry_from_constructor(new_true, service, user)
+    fn entry_new(service: &str, user: &str) -> Entry {
+        crate::tests::entry_from_constructor(SsCredential::new_with_target, service, user)
     }
 
     #[test]
     fn test_invalid_parameter() {
-        let credential = SsCredential::new_with_target(false, Some(""), "service", "user");
+        let credential = SsCredential::new_with_target(Some(""), "service", "user");
         assert!(
             matches!(credential, Err(Error::Invalid(_, _))),
             "Created entry with empty target"
@@ -288,150 +286,141 @@ mod tests {
 
     #[test]
     fn test_empty_service_and_user() {
-        crate::tests::test_empty_service_and_user(entry_new_false);
-        crate::tests::test_empty_service_and_user(entry_new_true);
+        crate::tests::test_empty_service_and_user(entry_new);
     }
 
     #[test]
     fn test_missing_entry() {
-        crate::tests::test_missing_entry(entry_new_false);
-        crate::tests::test_missing_entry(entry_new_true);
+        crate::tests::test_missing_entry(entry_new);
     }
 
     #[test]
     fn test_empty_password() {
-        crate::tests::test_empty_password(entry_new_false);
-        crate::tests::test_empty_password(entry_new_true);
+        crate::tests::test_empty_password(entry_new);
     }
 
     #[test]
     fn test_round_trip_ascii_password() {
-        crate::tests::test_round_trip_ascii_password(entry_new_false);
-        crate::tests::test_round_trip_ascii_password(entry_new_true);
+        crate::tests::test_round_trip_ascii_password(entry_new);
     }
 
     #[test]
     fn test_round_trip_non_ascii_password() {
-        crate::tests::test_round_trip_non_ascii_password(entry_new_false);
-        crate::tests::test_round_trip_non_ascii_password(entry_new_true);
+        crate::tests::test_round_trip_non_ascii_password(entry_new);
     }
 
     #[test]
     fn test_update() {
-        crate::tests::test_update(entry_new_false);
-        crate::tests::test_update(entry_new_true);
+        crate::tests::test_update(entry_new);
     }
 
     #[test]
     fn test_get_credential() {
-        fn test_get_credential_inner(entry: Entry) {
-            entry
-                .set_password("test get credential")
-                .expect("Can't set password for get_credential");
-            let credential: &SsCredential = entry
-                .get_credential()
-                .downcast_ref()
-                .expect("Not a linux credential");
-            let actual = credential.get_credential().expect("Can't read credential");
-            assert_eq!(actual.label, credential.label, "Labels don't match");
-            for (key, value) in &credential.attributes {
-                assert_eq!(
-                    actual.attributes.get(key).expect("Missing attribute"),
-                    value,
-                    "Attribute mismatch"
-                )
-            }
-            entry
-                .delete_password()
-                .expect("Couldn't delete get-credential");
-            assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
+        let name = generate_random_string();
+        let entry = entry_new(&name, &name);
+        entry
+            .set_password("test get credential")
+            .expect("Can't set password for get_credential");
+        let credential: &SsCredential = entry
+            .get_credential()
+            .downcast_ref()
+            .expect("Not a secret service credential");
+        let actual = credential.get_credential().expect("Can't read credential");
+        assert_eq!(actual.label, credential.label, "Labels don't match");
+        for (key, value) in &credential.attributes {
+            assert_eq!(
+                actual.attributes.get(key).expect("Missing attribute"),
+                value,
+                "Attribute mismatch"
+            )
         }
+        entry
+            .delete_password()
+            .expect("Couldn't delete get-credential");
+        assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
+    }
+
+    fn delete_collection(name: &str) {
+        use secret_service::blocking::SecretService;
+        pub use secret_service::EncryptionType;
+
+        let ss =
+            SecretService::connect(EncryptionType::Dh).expect("Can't connect to secret service");
+        let collection = ss
+            .get_collection_by_alias(name)
+            .expect("Can't find collection to delete");
+        collection.delete().expect("Can't delete collection");
+    }
+
+    #[test]
+    fn test_create_new_target_collection() {
+        let name = generate_random_string();
+        let credential = SsCredential::new_with_target(Some(&name), &name, &name)
+            .expect("Can't create new collection for credential");
+        let entry = Entry::new_with_credential(Box::new(credential));
+        let password = "password in new collection";
+        entry
+            .set_password(password)
+            .expect("Can't set password for new collection entry");
+        let actual = entry
+            .get_password()
+            .expect("Can't get password for new collection entry");
+        assert_eq!(actual, password);
+        entry
+            .delete_password()
+            .expect("Couldn't delete password for new collection entry");
+        assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
+        delete_collection(&name);
+    }
+
+    #[test]
+    fn test_separate_targets_dont_interfere() {
         let name1 = generate_random_string();
-        let entry1 = entry_new_false(&name1, &name1);
-        test_get_credential_inner(entry1);
         let name2 = generate_random_string();
-        let entry2 = entry_new_true(&name2, &name2);
-        test_get_credential_inner(entry2);
-    }
-
-    #[test]
-    fn test_search_collection_finds_and_replaces_search_all() {
-        let name = generate_random_string();
-        let entry1 = entry_new_false(&name, &name);
-        let entry2 = entry_new_true(&name, &name);
-        let password1 = "search-collection-finds-all";
-        entry2
-            .set_password(password1)
-            .expect("Can't set s-c-f-a password");
-        let found1 = entry1
-            .get_password()
-            .expect("Search collection doesn't find all");
-        assert_eq!(found1, password1, "Collection password doesn't match all");
-        let password2 = "set-collection-replaces-existing";
-        entry1
-            .set_password(password2)
-            .expect("Search collection couldn't set password");
-        entry2
-            .get_password()
-            .expect_err("target attribute wasn't replaced!");
-        entry2
-            .delete_password()
-            .expect_err("Delete succeeded on search-all credential");
-        entry1
-            .delete_password()
-            .expect("Delete failed on search-collection credential");
-    }
-
-    #[test]
-    fn test_search_all_doesnt_find_collection_and_creates_new() {
-        let name = generate_random_string();
-        let entry1 = entry_new_false(&name, &name);
-        let entry2 = entry_new_true(&name, &name);
-        let password1 = "search-all-doesn't find collection";
+        let credential1 = SsCredential::new_with_target(Some(&name1), &name1, &name1)
+            .expect("Can't create new collection for credential1");
+        let entry1 = Entry::new_with_credential(Box::new(credential1));
+        let credential2 = SsCredential::new_with_target(Some(&name2), &name1, &name1)
+            .expect("Can't create new collection for credential2");
+        let entry2 = Entry::new_with_credential(Box::new(credential2));
+        let entry3 = Entry::new(&name1, &name1).expect("Can't create entry in default collection");
+        let password1 = "password for collection 1";
+        let password2 = "password for collection 2";
+        let password3 = "password for default collection";
         entry1
             .set_password(password1)
-            .expect("Search collection couldn't set password");
-        entry2
-            .get_password()
-            .expect_err("Search all found collection password");
-        let password2 = "search-all-creates-new";
+            .expect("Can't set password for collection 1");
         entry2
             .set_password(password2)
-            .expect("Search all couldn't set password");
-        let err = entry1
+            .expect("Can't set password for collection 2");
+        entry3
+            .set_password(password3)
+            .expect("Can't set password for default collection");
+        let actual1 = entry1
             .get_password()
-            .expect_err("Search collection found only one password");
-        match err {
-            Error::Ambiguous(creds) => {
-                assert_eq!(creds.len(), 2, "Wrong number of found credentials");
-                let mut count = [0; 2];
-                for cred in creds {
-                    let credential: &SsCredential = cred
-                        .as_any()
-                        .downcast_ref()
-                        .expect("Not a linux credential");
-                    if credential.search_all {
-                        count[1] += 1
-                    } else {
-                        count[0] += 1
-                    }
-                }
-                assert!(
-                    count[0] == 1 && count[1] == 1,
-                    "Credentials not of different types"
-                );
-            }
-            _ => panic!("Didn't get an ambiguous error: {err}"),
-        }
-        let found = entry2
+            .expect("Can't get password for collection 1");
+        assert_eq!(actual1, password1);
+        let actual2 = entry2
             .get_password()
-            .expect("Search all couldn't get password");
-        assert_eq!(found, password2, "Search all found collection password");
-        entry2
-            .delete_password()
-            .expect("Delete failed on search-all credential");
+            .expect("Can't get password for collection 2");
+        assert_eq!(actual2, password2);
+        let actual3 = entry3
+            .get_password()
+            .expect("Can't get password for default collection");
+        assert_eq!(actual3, password3);
         entry1
             .delete_password()
-            .expect("Delete failed on search-collection credential after search-all deleted");
+            .expect("Couldn't delete password for collection 1");
+        assert!(matches!(entry1.get_password(), Err(Error::NoEntry)));
+        entry2
+            .delete_password()
+            .expect("Couldn't delete password for collection 2");
+        assert!(matches!(entry2.get_password(), Err(Error::NoEntry)));
+        entry3
+            .delete_password()
+            .expect("Couldn't delete password for default collection");
+        assert!(matches!(entry3.get_password(), Err(Error::NoEntry)));
+        delete_collection(&name1);
+        delete_collection(&name2);
     }
 }


### PR DESCRIPTION
Here's how it works:

1. We always use service-level search.  So no options are needed to turn it on or off.
2. We always add a `target` attribute when creating new items.
3. We always just search for the service and user.  So we find both v1-style entries (with no target attribute) and v2-style entries (with the target attribute).  We filter the found results so they are either v1-style entries (which are assumed to have a matching target) or v2-style entries with a matching target.
4. If we ever get multiple hits on a search, we return an ambiguous error.
5. `set-password` works by doing `get-password` and then, if it finds a unique item, setting the password on that item.  If there is no matching item, it creates one in a collection labeled by the target (creating that collection if necessary).  Note that the `default` target is the only collection found by alias; all other collections are found by label.

This seems to provide the best of all worlds: v1 and v2 are now completely compatible, and we can create collections if the client uses a non-default target.  (Note that v1 never created collections, and it always used the target name as an alias, so in effect it was completely restricted to using the default collection.)

If (due to 3rd party items) an ambiguity is found, there are platform-specific entries for getting all the passwords or deleting all the matching items.

Fixes #84.
Fixes #76.