### PR TITLE
Make `linux-keyutils` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ linux-secret-service-rt-tokio-crypto-rust = ["secret-service/rt-tokio-crypto-rus
 linux-secret-service-rt-async-io-crypto-openssl = ["secret-service/rt-async-io-crypto-openssl"]
 linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-openssl"]
 linux-no-secret-service = ["linux-default-keyutils"]
-linux-default-keyutils = []
+linux-default-keyutils = ["linux-keyutils"]
 
 [dependencies]
 lazy_static = "1"
@@ -32,7 +32,7 @@ security-framework = "2.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = { version = "3", optional = true }
-linux-keyutils = { version = "0.2", features = ["std"] }
+linux-keyutils = { version = "0.2", features = ["std"], optional = true }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 secret-service = { version = "3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub use error::{Error, Result};
 // It would be really nice if we could conditionalize multiple declarations,
 // but we can't so we have to repeat the conditional on each one.
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "linux-default-keyutils"))]
 pub mod keyutils;
 #[cfg(all(target_os = "linux", not(feature = "linux-no-secret-service")))]
 pub mod secret_service;


### PR DESCRIPTION
`linux-keyutils` [doesn't compile on some 32-bit platforms](https://github.com/landhb/linux-keyutils/issues/8), enable it unconditionally is troublesome.