### PR TITLE
Compatability Patch: Only use the persistent keyring if supported by the running kernel.

### DIFF
--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -77,8 +77,8 @@ impl CredentialApi for KeyutilsCredential {
             .map_err(decode_error)?;
 
         // Directly link to the persistent keyring as well
-        if let Some(persistent) = self.persistent {
-            persistent.link_key(key).map_err(decode_error)?;
+        if let Some(keyring) = self.persistent {
+            keyring.link_key(key).map_err(decode_error)?;
         }
         Ok(())
     }
@@ -102,8 +102,8 @@ impl CredentialApi for KeyutilsCredential {
         // Directly re-link to the persistent keyring
         // If it expired, it will only be linked to the
         // session keyring, and needs to be added again.
-        if let Some(persistent) = self.persistent {
-            persistent.link_key(key).map_err(decode_error)?;
+        if let Some(keyring) = self.persistent {
+            keyring.link_key(key).map_err(decode_error)?;
         }
 
         // Read in the key (making sure we have enough room)


### PR DESCRIPTION
@brotskydotcom This is just for maximum compatibility for clients. 

Technically the persistent keyring wasn't added until Linux kernel version 3.13, but the keyctl syscall was added in 2.6.

Even though 3.13 is fairly old now (released in 2014) it's probably worth supporting the older kernels just in case.

This isn't a breaking change so should be fine for the next patch release. If the persistent keyring exists, it will function as it has been. If it doesn't exist, there won't be a hard error for users and the key will still be stored in the Session keyring.
