### PR TITLE
Remove unnecessary clone/allocation in `decode_password`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -97,7 +97,7 @@ impl std::error::Error for Error {
 
 /// Try to interpret a byte vector as a password string
 pub fn decode_password(bytes: Vec<u8>) -> Result<String> {
-    String::from_utf8(bytes.clone()).map_err(|_| Error::BadEncoding(bytes))
+    String::from_utf8(bytes).map_err(|err| Error::BadEncoding(err.into_bytes()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Just a small fix I noticed while integrating `keyring` : )

The error returned by `String::from_utf8` actually gives us access to the original buffer: [`FromUtf8Error::into_bytes`](https://doc.rust-lang.org/stable/std/string/struct.FromUtf8Error.html#method.into_bytes). Using this lets us avoid an extra clone on the password buffer every time.