### PR TITLE
cfg-gate default credential builders so `keyring` builds on all platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,14 +142,7 @@ pub mod ios;
 #[cfg(target_os = "ios")]
 use ios as default;
 
-pub mod credential;
-pub mod error;
 pub mod mock;
-
-// Unsupported platforms use the mock backend as default. That way the crate
-// always compiles, but the user must provide their own backend to actually
-// persist keys.
-
 #[cfg(not(any(
     target_os = "linux",
     target_os = "freebsd",
@@ -158,6 +151,9 @@ pub mod mock;
     target_os = "windows",
 )))]
 use mock as default;
+
+pub mod credential;
+pub mod error;
 
 #[derive(Default, Debug)]
 struct EntryBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,19 @@ pub mod credential;
 pub mod error;
 pub mod mock;
 
+// Unsupported platforms use the mock backend as default. That way the crate
+// always compiles, but the user must provide their own backend to actually
+// persist keys.
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "windows",
+)))]
+use mock as default;
+
 #[derive(Default, Debug)]
 struct EntryBuilder {
     inner: Option<Box<CredentialBuilder>>,


### PR DESCRIPTION
Hi, I'm currently attempting to use `keyring` for a cross-platform app. One of the platforms (Android) doesn't have a default backend, so I've resorted to stuffing the credentials in the app's data directory for the time being. I've got that alternate `CredentialApi` impl built, but sadly `keyring` won't build for android for a small reason: there's no `default` module.

```bash
$ cargo check --target=aarch64-linux-android
    Checking keyring v2.0.2
error[E0433]: failed to resolve: use of undeclared crate or module `default`
   --> src/lib.rs:176:54
    |
176 |         static ref DEFAULT: Box<CredentialBuilder> = default::default_credential_builder();
    |                                                      ^^^^^^^
    |                                                      |
    |                                                      use of undeclared crate or module `default`
    |                                                      help: a struct with a similar name exists: `DEFAULT`

error: could not compile `keyring` (lib) due to previous error
```

To get around this (but still use the common `keyring` API across all platforms), this PR `#[cfg(..)]` gates `build_default_credential`, `Entry::new`, and `Entry::new_with_target`. That way they're only visible on platforms with default backends available. Unsupported platforms will get a compiler error if they try to use the default constructors.

Another approach would be to make it a runtime error rather than a compile-time error. Something like:

```rust
fn build_default_credential(..) -> Result<Entry> {
    cfg_if! {
        if #[cfg(any(target_os = "linux", ..))] {
            // existing fn body
        } else {
            Err(Error::NoDefaultBackend)
        }
    }
}
```

Otherwise `keyring` is working well for me : )