### PR TITLE
Add password only option to "cli get"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ libtest.rmeta
 *.profdata
 *.profraw
 
+.idea


### PR DESCRIPTION
This is useful if the command should be used from within a script .

Session (the errors now exit with 1) :

```
[11:05:12] λ  cargo run --example cli -- --service jasc-one get --password-only
whatever

[11:05:18] λ  cargo run --example cli -- --service jan-one get --password-only
(No password found for 'jan@jan-one')

[11:05:24] [1] ✗  cargo run --example cli -- --service jan-one get
(No password found for 'jan@jan-one')

[11:05:49] [1] ✗  cargo run --example cli -- --service jasc-one get
The password for 'jan@jasc-one' is 'whatever'
``` 

closes: #130