### PR TITLE
Make the cli suitable for scripting use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ whether through contributing code, discussion, or bug reports!
 - @dten
 - @gondolyr
 - @hwchen
+- @jankatins
 - @jasikpark
 - @jkhsjdhjs
 - @jonathanmorley


### PR DESCRIPTION
The CLI was very chatty about its operations, which made it unsuitable for use in scripts.  In addition, it always exited with a success (0) status, even when operations failed.

This change fixes both of those issues:

1. The cli doesn't output anything to stdout except when it retrieves a password successfully, in which case the password (alone) is output followed by a newline.
2. The cli doesn't output anything to stderr unless the -v (verbose) flag is specified, in which case it prints debugging info to stderr on all operations.
3. The cli exits with status 0 only for success; if an error is encountered it returns status 1.

Fixes hwchen/keyring-rs#130.