### PR TITLE
Update documentation for Linux Key Management Facility

### DIFF
--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -10,6 +10,56 @@ Entries in keyutils are identified by a string `description`.  If an entry is cr
 an explicit `target`, that value is used as the keyutils description.  Otherwise, the string
 `keyring-rs:user@service` is used (where user and service come from the entry creation call).
 
+# Persistence
+
+The key management facility provided by the kernel is completely in-memory and will not persist
+across reboots. Consider the keyring a secure cache and plan for your application to handle
+cases where the entry is no-longer available in-memory.
+
+In general you should prepare for `Entry::get_password` to fail and have a fallback to re-load
+the credential into memory.
+
+Potential options to re-load the credential into memory are:
+
+- Re-prompt the user (most common/effective for CLI applications)
+- Create a PAM module or use `pam_exec` to load a credential securely when the user logs in.
+- If you're running as a systemd service you can use `systemd-ask-password` to prompt the user
+  when your service starts.
+
+```
+use std::error::Error;
+use keyring::Entry;
+
+/// Simple user code that handles retrieving a credential regardless
+/// of the credential state.
+struct CredentialManager {
+    entry: Entry,
+}
+
+impl CredentialManager {
+    /// Init the service as normal
+    pub fn new(service: &str, user: &str) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            entry: Entry::new(service, user)?
+        })
+    }
+
+    /// Method that first attempts to retreive the credential from memory
+    /// and falls back to prompting the user.
+    pub fn get(&self) -> Result<String, Box<dyn Error>> {
+        self.entry.get_password().or_else(|_| self.prompt())
+    }
+
+    /// Internal method to prompt the user and cache the credential
+    /// in memory for subsequent lookups.
+    fn prompt(&self) -> Result<String, Box<dyn Error>> {
+        let password = rpassword::read_password()?;
+        self.entry.set_password(&password)?;
+        Ok(password)
+    }
+}
+```
+
 A single entry in keyutils can be on multiple "keyrings", each of which has a subtly
 different lifetime.  The core storage for keyring keys is provided by the user-specific
 [persistent keyring](https://www.man7.org/linux/man-pages/man7/persistent-keyring.7.html),
@@ -17,7 +67,25 @@ whose lifetime defaults to a few days (and is controllable by
 administrators).  But whenever an entry's credential is used,
 it is also added to the user's
 [session keyring](https://www.man7.org/linux/man-pages/man7/session-keyring.7.html):
-this ensures that the credential will persist as long as the client is running.
+this ensures that the credential will persist as long as the user session exists, and when the user
+logs out the credential will persist as long as the persistent keyring doesn't expire while the user is
+logged out.
+
+Each time the `Entry::new()` operation is performed, the persistent keyring's expiration timer
+is reset to the value configured in:
+
+```no_run,no_test,ignore
+proc/sys/kernel/keys/persistent_keyring_expiry
+```
+
+| Persistent Keyring State | Session Keyring State | User Key State |
+| -------------            | -------------         | -------------  |
+| Active                   | Active                | Active         |
+| Expired                  | Active                | Active         |
+| Active                   | Logged Out            | Active (Accessible on next login)        |
+| Expired                  | Logged Out            | Expired        |
+
+**Note**: As mentioned above, a reboot clears all keyrings.
 
 ## Headless usage
 


### PR DESCRIPTION
@brotskydotcom  Following up on https://github.com/hwchen/keyring-rs/issues/137.

This should clear up any confusion on the lifetimes of the kernel keyring.