### PR TITLE
Move to maintained action for installing rust toolchain.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,18 +24,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain (stable)
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Build (debug)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --all-targets
+        run: cargo build --verbose --all-targets
 
       - name: Linux tests
         if: matrix.os == 'ubuntu-latest'
@@ -43,19 +37,10 @@ jobs:
 
       - name: Non-linux tests
         if: matrix.os != 'ubuntu-latest'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose
 
       - name: Format check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy check
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,7 @@
 name: Publish executables
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'
@@ -27,18 +28,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain (stable)
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Build (release, locked)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --example cli
+        run: cargo build --release --example cli
 
       - name: Post cli executable
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
1. Replace actions-rs/toolchain with dtolnay/rust-toolchain.
2. Use cargo directly in build steps.