### PR TITLE
docs: document platform-specific behavior on Windows 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,10 @@ impl Entry {
     /// Create an entry for the given target, service, and user.
     ///
     /// The default credential builder is used.
+    ///
+    /// # Platform-specific behavior
+    ///
+    /// On Windows, `service` is ignored.
     pub fn new_with_target(target: &str, service: &str, user: &str) -> Result<Entry> {
         build_default_credential(Some(target), service, user)
     }


### PR DESCRIPTION
where `service` is not used.

This could lead to callers silently using a very generic collision-prone name like "token"

e.g. https://github.com/firezone/firezone/blob/main/rust/windows-client/src-tauri/src/client/gui.rs#L215-L219

I ran `cargo test` a few times and it passed once but failed other times. I think it isn't playing well with Rust's multi-threaded test framework.