### PR TITLE
Support OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ readme = "README.md"
 
 [features]
 default = ["platform-all"]
-platform-all = ["platform-linux", "platform-freebsd", "platform-macos", "platform-ios", "platform-windows"]
+platform-all = ["platform-linux", "platform-freebsd", "platform-openbsd", "platform-macos", "platform-ios", "platform-windows"]
 platform-linux = ["linux-secret-service", "linux-keyutils"]
 platform-freebsd = ["linux-secret-service"]
+platform-openbsd = ["linux-secret-service"]
 platform-macos = ["security-framework"]
 platform-ios = ["security-framework"]
 platform-windows = ["winapi", "byteorder"]
@@ -42,6 +43,9 @@ secret-service = { version = "3", optional = true }
 linux-keyutils = { version = "0.2", features = ["std"], optional = true }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
+secret-service = { version = "3", optional = true }
+
+[target.'cfg(target_os = "openbsd")'.dependencies]
 secret-service = { version = "3", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ Linux (secret-service and kernel keyutils),
 iOS (keychain), macOS (keychain), and
 Windows (credential manager).
 
-It also builds on FreeBSD (secret-service),
+It also builds on FreeBSD and OpenBSD (secret-service),
 and probably works there,
 but since neither the maintainers nor GitHub do
-building and testing on FreeBSD, we can't be sure.
+building and testing on BSDs, we can't be sure.
 
 The default features of this crate are set up
 to build all the available platform support.
@@ -117,7 +117,7 @@ PLEASE NOTE: As of version 2.2, turning off the default
 feature set will turn off platform support on *all* platforms,
 not just on Linux (as was the case before).  While this
 behavior is a breaking change on Mac, Windows,
-and FreeBSD, the behavior on those platforms before was
+FreeBSD and OpenBSD, the behavior on those platforms before was
 unintended and undefined (suppressing default features did nothing),
 so this is considered a bug fix rather than
 a semver-breaking change that requires a major version bump.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ A top-level introduction to the library's usage, as well as a small code sample,
 may be found in [the library's entry on crates.io](https://crates.io/crates/keyring).
 Currently supported platforms are
 Linux,
+FreeBSD,
+OpenBSD,
 Windows,
 macOS, and iOS.
 
@@ -147,6 +149,13 @@ use crate::secret_service as default;
 #[cfg(all(target_os = "freebsd", not(feature = "secret-service")))]
 use mock as default;
 
+#[cfg(all(target_os = "openbsd", feature = "secret-service"))]
+pub mod secret_service;
+#[cfg(all(target_os = "openbsd", feature = "secret-service"))]
+use crate::secret_service as default;
+#[cfg(all(target_os = "openbsd", not(feature = "secret-service")))]
+use mock as default;
+
 #[cfg(all(target_os = "macos", feature = "platform-macos"))]
 pub mod macos;
 #[cfg(all(target_os = "macos", feature = "platform-macos"))]
@@ -171,6 +180,7 @@ use mock as default;
 #[cfg(not(any(
     target_os = "linux",
     target_os = "freebsd",
+    target_os = "openbsd",
     target_os = "macos",
     target_os = "ios",
     target_os = "windows",


### PR DESCRIPTION
This came about as a build fix for OpenBSD's new spotifyd package:
```
error[E0433]: failed to resolve: use of undeclared crate or module `default`
  --> .../modcargo-crates/keyring-2.0.1/src/lib.rs:176:54
```

Local spotifyd patches to enable its keyring feature practically differ only in README.md and Cargo.toml churn;  this makes keyring-rs build fine by adapting existing FreeBSD bits.