### PR TITLE
Replace lazy_static with OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-
 linux-no-secret-service = ["linux-default-keyutils"]
 linux-default-keyutils = ["linux-keyutils"]
 
+[dependencies]
+once_cell = "1"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "2.6", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-
 linux-no-secret-service = ["linux-default-keyutils"]
 linux-default-keyutils = ["linux-keyutils"]
 
-[dependencies]
-once_cell = "1"
-
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "2.6", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,6 @@ linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-
 linux-no-secret-service = ["linux-default-keyutils"]
 linux-default-keyutils = ["linux-keyutils"]
 
-
-[dependencies]
-lazy_static = "1"
-
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "2.6", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,12 +216,14 @@ pub fn set_default_credential_builder(new: Box<CredentialBuilder>) {
 }
 
 fn build_default_credential(target: Option<&str>, service: &str, user: &str) -> Result<Entry> {
-    static DEFAULT: once_cell::sync::Lazy<Box<CredentialBuilder>> =
-        once_cell::sync::Lazy::new(|| default::default_credential_builder());
+    static DEFAULT: std::sync::OnceLock<Box<CredentialBuilder>> = std::sync::OnceLock::new();
     let guard = DEFAULT_BUILDER
         .read()
         .expect("Poisoned RwLock in keyring-rs: please report a bug!");
-    let builder = guard.inner.as_ref().unwrap_or_else(|| &DEFAULT);
+    let builder = guard
+        .inner
+        .as_ref()
+        .unwrap_or_else(|| DEFAULT.get_or_init(|| default::default_credential_builder()));
     let credential = builder.build(target, service, user)?;
     Ok(Entry { inner: credential })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,14 +216,12 @@ pub fn set_default_credential_builder(new: Box<CredentialBuilder>) {
 }
 
 fn build_default_credential(target: Option<&str>, service: &str, user: &str) -> Result<Entry> {
-    static DEFAULT: std::sync::OnceLock<Box<CredentialBuilder>> = std::sync::OnceLock::new();
+    static DEFAULT: once_cell::sync::Lazy<Box<CredentialBuilder>> =
+        once_cell::sync::Lazy::new(|| default::default_credential_builder());
     let guard = DEFAULT_BUILDER
         .read()
         .expect("Poisoned RwLock in keyring-rs: please report a bug!");
-    let builder = guard
-        .inner
-        .as_ref()
-        .unwrap_or_else(|| DEFAULT.get_or_init(|| default::default_credential_builder()));
+    let builder = guard.inner.as_ref().unwrap_or_else(|| &DEFAULT);
     let credential = builder.build(target, service, user)?;
     Ok(Entry { inner: credential })
 }


### PR DESCRIPTION
This pull request removes [`lazy_static`](https://crates.io/crates/lazy_static) in favour of [OnceLock](https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html). [OnceCell](https://github.com/matklad/once_cell) is technically a crate. However, it has been [partially merged](https://github.com/rust-lang/rust/pull/105587) into the standard library.

lazy_static hasn't had a release in 4 years and now has a [section](https://github.com/rust-lang-nursery/lazy-static.rs#standard-library) on its ReadMe that shows how to achieve the exact same thing with the standard library.