### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ libtest.rmeta
 # profiling
 *.profdata
 *.profraw
-
+# JetBrains IDEs
+.idea


### PR DESCRIPTION
`.idea` is a config folder created by JetBrains IDEs, notably RustRover, and is helpful to ignore for contributing.