### PR TITLE
Track down and avoid the windows test failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ linux-secret-service-rt-async-io-crypto-openssl = ["secret-service/rt-async-io-c
 linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-openssl"]
 linux-no-secret-service = ["linux-default-keyutils"]
 linux-default-keyutils = ["linux-keyutils"]
-
+windows-test-threading = []
 
 [dependencies]
 lazy_static = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,12 +101,17 @@ The returned error will have the raw bytes attached,
 so you can access them.
 
 While this crate's code is thread-safe,
-accessing the _same_ entry from multiple threads simultaneously
-can produce odd results, even deadlocks.
-This is because the system calls to the platform credential managers
-may do leasing of locks and serialize calls differently than
-they are made.  As long as you access a single entry from
+accessing the _same_ entry from multiple threads
+in close proximity may be unreliable (especially on Windows),
+in that the underlying platform
+store may actually execute those calls in a different
+order than they are made. As long as you access a single entry from
 only one thread at a time, multi-threading should be fine.
+
+(N.B. Creating an entry is not the same as accessing it, because
+entry creation doesn't go through the platform credential manager.
+It's fine to create an entry on one thread and then immediately use
+it on a different thread.  This is thoroughly tested on all platforms.)
  */
 pub use credential::{Credential, CredentialBuilder};
 pub use error::{Error, Result};

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -20,6 +20,14 @@ rather than concatenating the username and service.
 So if you have a custom algorithm you want to use for computing the Windows target name,
 you can specify the target name directly.  (You still need to provide a service and username,
 because they are used in the credential's metadata.)
+
+## Caveat
+
+Reads and writes of the same entry from multiple threads in close proximity
+are not guaranteed to be serialized by the Windows Credential Manager in
+the order in which they were made.  There are tests of this behavior in the
+test suite of this crate, and they have been observed to fail in both
+Windows 10 and Windows 11.
 */
 use byteorder::{ByteOrder, LittleEndian};
 use std::iter::once;

--- a/tests/threading.rs
+++ b/tests/threading.rs
@@ -65,13 +65,13 @@ fn test_create_set_then_move() {
 }
 
 #[test]
-fn test_simultaneous_create_set_move() {
+fn test_simultaneous_create_move_set() {
     let mut handles = vec![];
     for i in 0..10 {
         let name = format!("{}-{}", generate_random_string(), i);
         let entry = Entry::new(&name, &name).expect("Can't create entry");
-        entry.set_password(&name).expect("Can't set ascii password");
         let test = move || {
+            entry.set_password(&name).expect("Can't set ascii password");
             let stored_password = entry.get_password().expect("Can't get ascii password");
             assert_eq!(
                 stored_password, name,


### PR DESCRIPTION
I have altered the Windows tests so that they don't set a credential on one thread and then *immediately* access that credential from another thread.  With that change, the Windows tests seem to work reliably.

I have updated the docs to warn clients that this pattern of access is known to fail on Windows, and added a feature that can be used to run those tests on Windows in case Microsoft fixes these issues in future.

This "fixes #163" in a manner of speaking.