### PR TITLE
Implementation of keyring-search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ linux-secret-service-rt-tokio-crypto-rust = ["secret-service/rt-tokio-crypto-rus
 linux-secret-service-rt-async-io-crypto-openssl = ["secret-service/rt-async-io-crypto-openssl"]
 linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-openssl"]
 linux-no-secret-service = ["linux-default-keyutils"]
-linux-default-keyutils = ["linux-keyutils"]
+linux-default-keyutils = ["linux-keyutils", "keyring-search/linux-default-keyutils"]
 windows-test-threading = []
 
 [dependencies]
 lazy_static = "1"
-keyring-search = "1.1.1"
+keyring-search = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "2.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ rpassword = "7"
 rand = "0.8"
 doc-comment = "0.3"
 whoami = "1"
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+security-framework-sys = "2.11"
+core-foundation = "0.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ windows-test-threading = []
 
 [dependencies]
 lazy_static = "1"
+keyring-search = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "2.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ linux-secret-service-rt-async-io-crypto-rust = ["secret-service/rt-async-io-cryp
 linux-secret-service-rt-tokio-crypto-rust = ["secret-service/rt-tokio-crypto-rust"]
 linux-secret-service-rt-async-io-crypto-openssl = ["secret-service/rt-async-io-crypto-openssl"]
 linux-secret-service-rt-tokio-crypto-openssl = ["secret-service/rt-tokio-crypto-openssl"]
-linux-no-secret-service = ["linux-default-keyutils"]
+linux-no-secret-service = ["linux-default-keyutils", "keyring-search/linux-no-secret-service"]
 linux-default-keyutils = ["linux-keyutils", "keyring-search/linux-default-keyutils"]
 windows-test-threading = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ windows-test-threading = []
 
 [dependencies]
 lazy_static = "1"
-keyring-search = "1"
+keyring-search = "1.1.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "2.6", optional = true }

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,9 +1,11 @@
 extern crate keyring;
 
+use std::io::Write;
+
 use clap::Parser;
 use rpassword::prompt_password;
 
-use keyring::{Entry, Error, Result};
+use keyring::{CredentialSearchResult, Entry, Error, Result};
 
 fn main() {
     let mut args: Cli = Cli::parse();
@@ -24,21 +26,37 @@ fn main() {
         Command::Set { .. } => {
             let password = args.get_password();
             match entry.set_password(&password) {
-                Ok(()) => args.success_message_for(Some(&password)),
+                Ok(()) => args.success_message_for(Some(&password), None),
                 Err(err) => args.error_message_for(err),
             }
         }
         Command::Get => match entry.get_password() {
             Ok(password) => {
                 println!("{password}");
-                args.success_message_for(Some(&password));
+                args.success_message_for(Some(&password), None);
             }
             Err(err) => args.error_message_for(err),
         },
         Command::Delete => match entry.delete_password() {
-            Ok(()) => args.success_message_for(None),
+            Ok(()) => args.success_message_for(None, None),
             Err(err) => args.error_message_for(err),
         },
+        Command::Search { .. } => {
+            let results = Entry::search(&args.get_query());
+            let list = Entry::list_max(&results, 5);
+
+            println!("{list}");
+            args.flush();
+
+            if list == "Search returned no results".to_string() {
+                std::process::exit(0)
+            }
+
+            if args.entry_from_results() {
+                let entries = args.create_entry_vec(&results);
+                args.select_entries(entries);
+            }
+        }
     }
 }
 
@@ -79,6 +97,13 @@ pub enum Command {
     Get,
     /// Delete the entry from the secure store
     Delete,
+    /// Search for entries
+    Search {
+        #[clap(value_parser)]
+        /// The value to search for. If not specified, the
+        /// query is collected interactively from the terminal.
+        query: Option<String>,
+    },
 }
 
 impl Cli {
@@ -118,13 +143,16 @@ impl Cli {
                     Command::Delete => {
                         eprintln!("Couldn't set password for '{description}': {err}");
                     }
+                    Command::Search { .. } => {
+                        eprintln!("Couldn't search for '{description}: {err} ")
+                    }
                 },
             }
         }
         std::process::exit(1)
     }
 
-    fn success_message_for(&self, password: Option<&str>) {
+    fn success_message_for(&self, password: Option<&str>, query: Option<&str>) {
         if !self.verbose {
             return;
         }
@@ -141,6 +169,10 @@ impl Cli {
             Command::Delete => {
                 eprintln!("Successfully deleted password for '{description}'");
             }
+            Command::Search { .. } => {
+                let q = query.unwrap();
+                eprintln!("Successfully searched for '{q}'");
+            }
         }
     }
 
@@ -149,7 +181,7 @@ impl Cli {
             Command::Set {
                 password: Some(password),
             } => password.clone(),
-            Command::Set { password: None } => {
+            Command::Set { password: None } | Command::Search { .. } => {
                 if let Ok(password) = prompt_password("Password: ") {
                     password
                 } else {
@@ -160,6 +192,183 @@ impl Cli {
                 }
             }
             _ => String::new(),
+        }
+    }
+
+    fn get_query(&self) -> String {
+        match &self.command {
+            Command::Search { query: Some(query) } => query.clone(),
+            Command::Search { query: None } => {
+                print!("Search query: ");
+                self.flush();
+                let mut input = String::new();
+                match std::io::stdin().read_line(&mut input) {
+                    Ok(_) => {
+                        input.trim().to_string() // trim to remove newline
+                    }
+                    Err(err) => {
+                        if self.verbose {
+                            eprintln!("Failed to read query from terminal: {}", err);
+                        }
+                        std::process::exit(1)
+                    }
+                }
+            }
+            _ => String::new(),
+        }
+    }
+
+    fn entry_from_results(&self) -> bool {
+        print!("Would you like to modify any searched entries? (y/n) ");
+        self.flush();
+        let mut input = String::new();
+        self.read_line(&mut input);
+        match input.trim().to_ascii_lowercase().as_str() {
+            "y" => return true,
+            "n" => {
+                println!("Exiting, goodbye!");
+                std::process::exit(0);
+            }
+            _ => self.entry_from_results(),
+        }
+    }
+
+    fn create_entry_vec(&self, results: &CredentialSearchResult) -> Vec<Entry> {
+        let mut entries = vec![];
+
+        let size = match results.as_ref() {
+            Ok(results) => results.keys().len(),
+            Err(err) => {
+                if !self.verbose {
+                    eprintln!("Error getting size of result map: {err}");
+                }
+                std::process::exit(1)
+            }
+        };
+
+        for id in 1..=size {
+            let entry = match Entry::from_search_results(&results, id) {
+                Ok(entry) => entry,
+                Err(err) => {
+                    if self.verbose {
+                        eprintln!("Could not create entry from credential '{id}': {err}");
+                    }
+                    std::process::exit(1);
+                }
+            };
+            entries.push(entry);
+        }
+
+        entries
+    }
+
+    fn select_entries(&self, entries: Vec<Entry>) {
+        print!("Enter the ID of the entry you would like to modify: ");
+        self.flush();
+        let mut id = String::new();
+
+        self.read_line(&mut id);
+        self.modify_entries(entries, self.check_id(id));
+    }
+
+    fn check_id(&self, id: String) -> usize {
+        match id.trim().to_string().parse::<usize>() {
+            Ok(id) => id,
+            Err(err) => {
+                if self.verbose {
+                    eprintln!("Failed to parse ID from String to usize: {err}");
+                }
+                std::process::exit(1)
+            }
+        }
+    }
+
+    fn modify_entries(&self, entries: Vec<Entry>, id: usize) {
+        if id <= entries.len() {
+            let mut select = String::new();
+            let entry = &entries[id - 1];
+
+            println!("How would you like to modify this entry?\n");
+            println!("1. Set new password");
+            println!("2. Get current password");
+            println!("3. Delete credential\n");
+            self.flush();
+
+            self.read_line(&mut select);
+
+            match select.trim().to_ascii_lowercase().as_str() {
+                "1" => {
+                    let password = self.get_password();
+                    match entry.set_password(&password) {
+                        Ok(_) => {
+                            println!("Set password '{password}' for credential {id}");
+                            std::process::exit(0);
+                        }
+                        Err(err) => {
+                            if self.verbose {
+                                eprintln!("Error setting password for credential {id}: {err}");
+                            }
+                            std::process::exit(1);
+                        }
+                    };
+                }
+                "2" => {
+                    let password = match entry.get_password() {
+                        Ok(password) => password,
+                        Err(err) => {
+                            if self.verbose {
+                                eprintln!("Error getting entry password: {err}");
+                            }
+                            std::process::exit(1)
+                        }
+                    };
+
+                    println!("Password is '{password}' for credential {id}");
+                    std::process::exit(0);
+                }
+                "3" => {
+                    match entry.delete_password() {
+                        Ok(_) => {
+                            println!("Credential w/ ID: {id} deleted");
+                            std::process::exit(0);
+                        }
+                        Err(err) => {
+                            if self.verbose {
+                                eprintln!("Error deleting credential {id}: {err}");
+                            }
+                            std::process::exit(1);
+                        }
+                    };
+                }
+                _ => {
+                    println!("Invalid input");
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+
+    fn flush(&self) {
+        match std::io::stdout().flush() {
+            Ok(_) => {}
+            Err(err) => {
+                if self.verbose {
+                    eprintln!("Failed to flush stdout: {err}");
+                }
+                std::process::exit(1)
+            }
+        }
+    }
+
+    fn read_line(&self, input: &mut String) {
+        match std::io::stdin().read_line(input) {
+            Ok(_) => {}
+            Err(err) => {
+                if self.verbose {
+                    eprintln!("Failed to read line: {}", err);
+                }
+                std::process::exit(1)
+            }
         }
     }
 }

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -49,9 +49,9 @@ fn main() {
             } else {
                 list = Entry::list_results(&results)
             }
+
             println!("{list}");
             args.flush();
-
             if list == "Search returned no results".to_string() {
                 std::process::exit(0)
             }
@@ -259,9 +259,7 @@ impl Cli {
             let entry = match Entry::from_search_results(&results, id) {
                 Ok(entry) => entry,
                 Err(err) => {
-                    if self.verbose {
-                        eprintln!("Could not create entry from credential '{id}': {err}");
-                    }
+                    self.error_message_for(err);
                     std::process::exit(1);
                 }
             };
@@ -285,8 +283,8 @@ impl Cli {
             Ok(id) => id,
             Err(err) => {
                 if self.verbose {
-                    eprintln!("Failed to parse ID from String to usize: {err}");
-                }
+                    eprintln!("Error parsing id to usize type: {err:#?}");
+                };
                 std::process::exit(1)
             }
         }
@@ -314,9 +312,7 @@ impl Cli {
                             std::process::exit(0);
                         }
                         Err(err) => {
-                            if self.verbose {
-                                eprintln!("Error setting password for credential {id}: {err}");
-                            }
+                            self.error_message_for(err);
                             std::process::exit(1);
                         }
                     };
@@ -325,9 +321,7 @@ impl Cli {
                     let password = match entry.get_password() {
                         Ok(password) => password,
                         Err(err) => {
-                            if self.verbose {
-                                eprintln!("Error getting entry password: {err}");
-                            }
+                            self.error_message_for(err);
                             std::process::exit(1)
                         }
                     };
@@ -342,9 +336,7 @@ impl Cli {
                             std::process::exit(0);
                         }
                         Err(err) => {
-                            if self.verbose {
-                                eprintln!("Error deleting credential {id}: {err}");
-                            }
+                            self.error_message_for(err);
                             std::process::exit(1);
                         }
                     };

--- a/linux-test.sh
+++ b/linux-test.sh
@@ -2,3 +2,4 @@
 rm -f $HOME/.local/share/keyrings/*
 echo -n "test" | gnome-keyring-daemon --unlock
 cargo test --verbose
+cargo test --features "linux-no-secret-service" --verbose

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -150,6 +150,31 @@ impl CredentialBuilderApi for IosCredentialBuilder {
     }
 }
 
+pub fn entry_from_search(credential: &std::collections::HashMap<String, String>) -> Result<Entry> {
+    let service = if let Some(service) = credential.get(&"svce".to_string()) {
+        service
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values iOS, svce".to_string(),
+            "No svce key found in credential".to_string(),
+        ));
+    };
+    let account = if let Some(account) = credential.get(&"acct".to_string()) {
+        account
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values MacOS, acct".to_string(),
+            "No user key found in credential".to_string(),
+        ));
+    };
+    let ioscredential = Box::new(IosCredential {
+        service: service.to_string(),
+        account: account.to_string(),
+    });
+
+    Ok(Entry::new_with_credential(maccredential))
+}
+
 /// Map an iOS API error to a crate error with appropriate annotation
 ///
 /// The iOS error code values used here are from

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -16,6 +16,7 @@ wildcards when looking up credentials by attribute value.)
 On iOS, the target parameter is ignored, because there is only one keychain
 that can be targeted to store a generic credential.
  */
+use crate::Entry;
 use security_framework::base::Error;
 use security_framework::passwords::{
     delete_generic_password, get_generic_password, set_generic_password,
@@ -163,7 +164,7 @@ pub fn entry_from_search(credential: &std::collections::HashMap<String, String>)
         account
     } else {
         return Err(ErrorCode::Invalid(
-            "get entry values MacOS, acct".to_string(),
+            "get entry values iOS, acct".to_string(),
             "No user key found in credential".to_string(),
         ));
     };
@@ -172,7 +173,7 @@ pub fn entry_from_search(credential: &std::collections::HashMap<String, String>)
         account: account.to_string(),
     });
 
-    Ok(Entry::new_with_credential(maccredential))
+    Ok(Entry::new_with_credential(ioscredential))
 }
 
 /// Map an iOS API error to a crate error with appropriate annotation

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -101,6 +101,7 @@ use super::credential::{
     Credential, CredentialApi, CredentialBuilder, CredentialBuilderApi, CredentialPersistence,
 };
 use super::error::{decode_password, Error as ErrorCode, Result};
+use crate::Entry;
 use linux_keyutils::{KeyError, KeyRing, KeyRingIdentifier};
 
 /// Representation of a keyutils credential.
@@ -319,10 +320,8 @@ fn wrap(err: KeyError) -> Box<dyn std::error::Error + Send + Sync> {
     Box::new(err)
 }
 
-pub fn get_entry_values(
-    credential: &std::collections::HashMap<String, String>,
-) -> Result<[&String; 3]> {
-    let target = if let Some(target) = credential.get(&"description".to_string()) {
+pub fn entry_from_search(credential: &std::collections::HashMap<String, String>) -> Result<Entry> {
+    let description = if let Some(target) = credential.get(&"description".to_string()) {
         target
     } else {
         return Err(ErrorCode::Invalid(
@@ -330,15 +329,8 @@ pub fn get_entry_values(
             "No target key found in credential".to_string(),
         ));
     };
-    let user = if let Some(user) = credential.get(&"uid".to_string()) {
-        user
-    } else {
-        return Err(ErrorCode::Invalid(
-            "get entry values, user".to_string(),
-            "No user key found in credential".to_string(),
-        ));
-    };
-    Ok([target, target, user])
+
+    Entry::new_with_target(description, "", "")
 }
 
 #[cfg(test)]
@@ -424,4 +416,11 @@ mod tests {
             .expect("Couldn't delete after get_credential");
         assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
     }
+
+    #[test]
+    fn test_search_no_duplicates() {}
+    #[test]
+    fn test_entry_from_search() {}
+    #[test]
+    fn test_entries_from_search() {}
 }

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -419,6 +419,9 @@ mod tests {
         assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
     }
 
+    // The below functions are only used if --features "linux-no-secret-service' 
+    // is passed, therefore we allow dead code
+    #[allow(dead_code)]
     fn get_key_type(key_type: KeyType) -> String {
         match key_type {
             KeyType::KeyRing => "KeyRing".to_string(),
@@ -428,6 +431,7 @@ mod tests {
         }
     }
     // Converts permission bits to their corresponding permission characters to match keyctl command in terminal.
+    #[allow(dead_code)]
     fn get_permission_chars(permission_data: u8) -> String {
         let perm_types = [
             Permission::VIEW.bits(),
@@ -456,6 +460,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(
+        feature = "linux-no-secret-service",
+        not(feature = "secret-service")
+    ))]
     fn test_search() {
         let name = generate_random_string();
         let keyutils = KeyutilsCredential::new_with_target(Some(&name), &name, &name)
@@ -496,6 +504,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(
+        feature = "linux-no-secret-service",
+        not(feature = "secret-service")
+    ))]
     fn test_entry_from_search() {
         let name = generate_random_string();
         let password1 = "password1";

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -419,7 +419,7 @@ mod tests {
         assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
     }
 
-    // The below functions are only used if --features "linux-no-secret-service' 
+    // The below functions are only used if --features "linux-no-secret-service'
     // is passed, therefore we allow dead code
     #[allow(dead_code)]
     fn get_key_type(key_type: KeyType) -> String {
@@ -460,10 +460,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(
-        feature = "linux-no-secret-service",
-        not(feature = "secret-service")
-    ))]
+    #[cfg(any(feature = "linux-no-secret-service", not(feature = "secret-service")))]
     fn test_search() {
         let name = generate_random_string();
         let keyutils = KeyutilsCredential::new_with_target(Some(&name), &name, &name)
@@ -504,10 +501,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(
-        feature = "linux-no-secret-service",
-        not(feature = "secret-service")
-    ))]
+    #[cfg(any(feature = "linux-no-secret-service", not(feature = "secret-service")))]
     fn test_entry_from_search() {
         let name = generate_random_string();
         let password1 = "password1";

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -319,6 +319,28 @@ fn wrap(err: KeyError) -> Box<dyn std::error::Error + Send + Sync> {
     Box::new(err)
 }
 
+pub fn get_entry_values(
+    credential: &std::collections::HashMap<String, String>,
+) -> Result<[&String; 3]> {
+    let target = if let Some(target) = credential.get(&"description".to_string()) {
+        target
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values, target".to_string(),
+            "No target key found in credential".to_string(),
+        ));
+    };
+    let user = if let Some(user) = credential.get(&"uid".to_string()) {
+        user
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values, user".to_string(),
+            "No user key found in credential".to_string(),
+        ));
+    };
+    Ok([target, target, user])
+}
+
 #[cfg(test)]
 mod tests {
     use crate::credential::CredentialPersistence;

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -416,11 +416,4 @@ mod tests {
             .expect("Couldn't delete after get_credential");
         assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
     }
-
-    #[test]
-    fn test_search_no_duplicates() {}
-    #[test]
-    fn test_entry_from_search() {}
-    #[test]
-    fn test_entries_from_search() {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ use std::collections::HashMap;
 
 pub use credential::{Credential, CredentialBuilder};
 pub use error::{Error, Result};
-use keyring_search::{
+pub use keyring_search::{
     search::CredentialSearchApi, CredentialSearchResult, Error as SearchError, Limit, List, Search,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ impl Entry {
             results.push(user_result)
         }
 
-        if results.len() == 0 {
+        if results.is_empty() {
             return Err(SearchError::NoResults);
         } else if results.len() == 1 {
             let result = results[0].clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,9 +390,9 @@ impl Entry {
     /// The outer map's key corresponds to the ID of the result from 1 to the length of the map.
     /// The inner map contains the keys and values of the metadata of the result, i.e.
     /// target, service, user, last modified/date written, etc. In the case of keyutils, the Linux
-    /// Kernel keystore provides IDs for all credentials, the user must know the ID of the credential 
+    /// Kernel keystore provides IDs for all credentials, the user must know the ID of the credential
     /// to manipulate and pass this value to `from_search_results`. Since keyutils only returns one
-    /// result, this is the only valid parameter. 
+    /// result, this is the only valid parameter.
     /// # Example
     /// First result:
     /// ```rust
@@ -427,12 +427,8 @@ impl Entry {
             Some(credential) => credential.1,
             None => return Err(Error::NoEntry),
         };
-        // values[0] = target
-        // values[1] = service
-        // values[2] = user
-        let values: [&String; 3] = default::get_entry_values(credential)?;
 
-        Self::new_with_target(values[0], values[1], values[2])
+        default::entry_from_search(credential)
     }
 }
 
@@ -447,8 +443,6 @@ doc_comment::doctest!("../README.md", readme);
 // Since iOS doesn't use any of these generics, we allow dead code.
 #[allow(dead_code)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::{credential::CredentialApi, Entry, Error, Result};
 
     /// Create a platform-specific credential given the constructor, service, and user
@@ -570,158 +564,5 @@ mod tests {
             &entry,
             "このきれいな花は桜です",
         );
-    }
-
-    #[test]
-    fn test_search_no_duplicates() {
-        let names = vec![
-            generate_random_string(),
-            generate_random_string(),
-            generate_random_string(),
-        ];
-
-        let mut entries = Vec::new();
-
-        for name in &names {
-            entries.push(
-                Entry::new_with_target(&name, "test-service", "test-user")
-                    .expect("Error constructing entry"),
-            )
-        }
-
-        for entry in &entries {
-            entry
-                .set_password("test-password")
-                .expect("Error setting password")
-        }
-
-        let search_users = keyring_search::List::list_credentials(
-            &Entry::search_users("test"),
-            keyring_search::Limit::All,
-        );
-        let users_set: HashSet<&str> = search_users.lines().collect();
-        let search_services = keyring_search::List::list_credentials(
-            &Entry::search_services("test"),
-            keyring_search::Limit::All,
-        );
-        let services_set: HashSet<&str> = search_services.lines().collect();
-        let search_default = keyring_search::List::list_credentials(
-            &Entry::search("test"),
-            keyring_search::Limit::All,
-        );
-        let search_set: HashSet<&str> = search_default.lines().collect();
-
-        assert_eq!(users_set, services_set);
-        assert_eq!(users_set, search_set);
-        assert_eq!(services_set, search_set);
-
-        for entry in &entries {
-            entry.delete_password().expect("error deleting entry")
-        }
-    }
-
-    #[test]
-    fn test_entry_from_search() {
-        let name = generate_random_string();
-        let password1 = "password1";
-        let password2 = "password2";
-        let entry = Entry::new_with_target(&name, "test-service", "test-user")
-            .expect("Error creating new entry");
-        entry
-            .set_password(password1)
-            .expect("error setting password1");
-
-        let old_password = entry
-            .get_password()
-            .expect("failed to get password from old entry");
-        let results = &Entry::search(&name);
-
-        let result_entry =
-            Entry::from_search_results(results, 1).expect("Failed to create entry from results");
-        result_entry
-            .set_password(password2)
-            .expect("error setting password2");
-
-        let new_password = result_entry
-            .get_password()
-            .expect("Failed to get password from new entry");
-
-        assert_eq!(password1, old_password);
-        assert_eq!(password2, new_password);
-
-        result_entry
-            .delete_password()
-            .expect("Failed to delete new entry");
-        let e = entry.delete_password().unwrap_err();
-
-        assert!(matches!(e, Error::NoEntry));
-    }
-
-    #[test]
-    fn test_entries_from_search() {
-        let names = [
-            generate_random_string(),
-            generate_random_string(),
-            generate_random_string(),
-        ];
-
-        let mut entries: Vec<Entry> = vec![];
-        let password1 = "password1";
-        let password2 = "password2";
-        for name in names {
-            let entry = Entry::new_with_target(&name, "test-service", "test-user")
-                .expect("Error creating new entry");
-            entry
-                .set_password(password1)
-                .expect("error setting password1");
-            entries.push(entry);
-        }
-
-        let mut old_passwords = vec![];
-
-        for entry in &entries {
-            let old_password = entry
-                .get_password()
-                .expect("failed to get password from old entry");
-            old_passwords.push(old_password);
-        }
-
-        let result = &Entry::search("test");
-
-        let size = result
-            .as_ref()
-            .expect("Error getting size of outer map")
-            .keys()
-            .len(); 
-        let mut result_entries: Vec<Entry> = vec![];
-        for index in 1..=size {
-            let msg = format!("Failed to create entry at index: {index}");
-            let entry = Entry::from_search_results(result, index).expect(&msg);
-            entry
-                .set_password(&password2)
-                .expect("Error setting new password");
-            result_entries.push(entry);
-        }
-
-        let mut new_passwords = vec![];
-
-        for entry in &result_entries {
-            let new_password = entry.get_password().expect("error getting new password");
-            new_passwords.push(new_password);
-        }
-
-        for i in 0..new_passwords.len() {
-            assert_eq!(password1, old_passwords[i]);
-            assert_eq!(password2, new_passwords[i]);
-        }
-
-        for entry in &result_entries {
-            entry.delete_password().expect("Error deleting password");
-        }
-
-        for entry in &entries {
-            let e = entry.delete_password().unwrap_err();
-            assert!(matches!(e, Error::NoEntry));
-        }
     }
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -221,6 +221,36 @@ fn get_keychain(cred: &MacCredential) -> Result<SecKeychain> {
     }
 }
 
+pub fn get_entry_values(
+    credential: &std::collections::HashMap<String, String>,
+) -> Result<[&String; 3]> {
+    let target = if let Some(target) = credential.get(&"labl".to_string()) {
+        target
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values MacOS, labl".to_string(),
+            "No target key found in credential".to_string(),
+        ));
+    };
+    let comment = if let Some(comment) = credential.get(&"svce".to_string()) {
+        comment
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values MacOS, svce".to_string(),
+            "No comment key found in credential".to_string(),
+        ));
+    };
+    let user = if let Some(user) = credential.get(&"usr".to_string()) {
+        user
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values MacOS, usr".to_string(),
+            "No user key found in credential".to_string(),
+        ));
+    };
+    Ok([target, comment, user])
+}
+
 /// Map a Mac API error to a crate error with appropriate annotation
 ///
 /// The MacOS error code values used here are from

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -459,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    fn entry_from_search() {
+    fn test_entry_from_search() {
         let name = generate_random_string();
         let password1 = "password1";
         let password2 = "password2";

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -402,6 +402,36 @@ pub fn matching_target_items<'a>(
     Ok(result)
 }
 
+pub fn get_entry_values(
+    credential: &std::collections::HashMap<String, String>,
+) -> Result<[&String; 3]> {
+    let target = if let Some(target) = credential.get(&"application".to_string()) {
+        target
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values SecretService, application".to_string(),
+            "No target key found in credential".to_string(),
+        ));
+    };
+    let comment = if let Some(comment) = credential.get(&"service".to_string()) {
+        comment
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values SecretService, service".to_string(),
+            "No comment key found in credential".to_string(),
+        ));
+    };
+    let user = if let Some(user) = credential.get(&"username".to_string()) {
+        user
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values SecretService, username".to_string(),
+            "No user key found in credential".to_string(),
+        ));
+    };
+    Ok([target, comment, user])
+}
+
 //
 // Error utilities
 //

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -692,11 +692,4 @@ mod tests {
             .expect("Couldn't delete password for default collection");
         assert!(matches!(entry3.get_password(), Err(Error::NoEntry)));
     }
-
-    #[test]
-    fn test_search_no_duplicates() {}
-    #[test]
-    fn test_entry_from_search() {}
-    #[test]
-    fn test_entries_from_search() {}
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -365,6 +365,36 @@ unsafe fn from_wstr(ws: *const u16) -> String {
     String::from_utf16_lossy(slice)
 }
 
+pub fn get_entry_values(
+    credential: &std::collections::HashMap<String, String>,
+) -> Result<[&String; 3]> {
+    let target = if let Some(target) = credential.get(&"Target".to_string()) {
+        target
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values Windows, target".to_string(),
+            "No target key found in credential".to_string(),
+        ));
+    };
+    let comment = if let Some(comment) = credential.get(&"Comment".to_string()) {
+        comment
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values Windows, service/comment".to_string(),
+            "No comment key found in credential".to_string(),
+        ));
+    };
+    let user = if let Some(user) = credential.get(&"User".to_string()) {
+        user
+    } else {
+        return Err(ErrorCode::Invalid(
+            "get entry values Windows, user".to_string(),
+            "No user key found in credential".to_string(),
+        ));
+    };
+    Ok([target, comment, user])
+}
+
 /// Windows error codes are `DWORDS` which are 32-bit unsigned ints.
 #[derive(Debug)]
 pub struct Error(pub u32);


### PR DESCRIPTION
An implementation of keyring-search into the keyring crate. 

So far efforts have been made for all platform specific modules. However, the mock module remains untouched. Some work has been done to attempt to get this to work using generics and now modified keyring-search `MockCredentialStore`. I am hoping for some collaboration in getting this to work. 

The CLI example has been modified to show the functionality of the crate, with the ability to search and create entries from those search results. 

The search function uses all three of the keyring-search by methods (`by_user`, `by_target`, `by_service`) and then filters duplicate results. This way clients need not specify extra parameters and simply pass a search query. 