### PR TITLE
Add Sync trait bound to error variants.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,13 +25,13 @@ pub enum Error {
     /// This indicates runtime failure in the underlying
     /// platform storage system.  The details of the failure can
     /// be retrieved from the attached platform error.
-    PlatformFailure(Box<dyn std::error::Error + Send>),
+    PlatformFailure(Box<dyn std::error::Error + Send + Sync>),
     /// This indicates that the underlying secure storage
     /// holding saved items could not be accessed.  Typically this
     /// is because of access rules in the platform; for example, it
     /// might be that the credential store is locked.  The underlying
     /// platform error will typically give the reason.
-    NoStorageAccess(Box<dyn std::error::Error + Send>),
+    NoStorageAccess(Box<dyn std::error::Error + Send + Sync>),
     /// This indicates that there is no underlying credential
     /// entry in the platform for this entry.  Either one was
     /// never set, or it was deleted.


### PR DESCRIPTION
I found that after upgrading to v3 and calling the `Entry` functions and converting to `anyhow::Result` caused a compiler error due to unsatisfied trait bounds:

```
error[E0277]: `(dyn StdError + std::marker::Send + 'static)` cannot be shared between threads safely
   --> rust/src/api/keyring.rs:37:57
    |
37  |             entry.set_password(password.expose_secret())?;
    |                                                         ^ `(dyn StdError + std::marker::Send + 'static)` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `(dyn StdError + std::marker::Send + 'static)`, which is required by `Result<(), anyhow::Error>: FromResidual<Result<Infallible, keyring::Error>>`
    = help: the following other types implement trait `FromResidual<R>`:
              <Result<T, F> as FromResidual<Yeet<E>>>
              <Result<T, F> as FromResidual<Result<Infallible, E>>>
    = note: required for `Unique<(dyn StdError + std::marker::Send + 'static)>` to implement `std::marker::Sync`
note: required because it appears within the type `Box<(dyn StdError + std::marker::Send + 'static)>`
```

Adding the `Sync` trait bound to the error variants fixes this issue.