### PR TITLE
Release 3.0.2-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Version 3.0.2
+- add missing implementations for iOS `set_secret` and `get_secret`
+
+## Version 3.0.1
+- add back missing `Sync` trait on errors.
+
+## Version 3.0.0
+- add `dbus-secret-service` dependency to allow use on \*n\*x without an async runtime
+- (API change) rework feature controls on included keystores: now there is a feature for each keystore, and that keystore is included in a build if and only if its feature is specified *and* the keystore is supported by the target OS.
+- (API change) add direct support for setting and reading binary secret data, not just UTF-8 strings.
+
 ## Version 2.0.1
 - fix the example in the README.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "3.0.1"
+version = "3.0.2-rc.1"
 rust-version = "1.75"
 edition = "2021"
 exclude = [".github/"]
@@ -28,11 +28,8 @@ vendored = ["dbus-secret-service?/vendored", "openssl?/vendored"]
 [dependencies]
 openssl = { version = "0.10.55", optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-security-framework = { version = "2.6", optional = true }
-
-[target.'cfg(target_os = "ios")'.dependencies]
-security-framework = { version = "2.6", optional = true }
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]  # see issue #190
+security-framework = { git = "https://github.com/brotskydotcom/rust-security-framework.git", branch = "fix-issue-206", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = { version = "4", optional = true }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ This crate provides built-in implementations of the following platform-specific 
 * _macOS_, _iOS_: The local keychain.
 * _Windows_: The Windows Credential Manager.
 
-To enable the stores you want, you use features. If you don't enable any stores for a given platform, the _mock_ keystore will be used. See the [developer docs](https://docs.rs/keyring/) for details.
+To enable the stores you want, you use features: there is one feature for each possibly-included credential store. If you specify a feature (e.g., `dbus-secret-service`) _and_ your target platform (e.g., `freebsd`) supports that credential store, it will be included as the default credential store in that build. That way you can have a build command that specifies a single credential store for each of your target platforms, and use that same build command for all targets.
+
+If you don't enable any credential stores that are supported on a specific target, the _mock_ keystore will be the default on that target. If you enable multiple credential stores for a specific target, you will get a compile error. See the [developer docs](https://docs.rs/keyring/) for details of which features control the inclusion of which credential stores (and which platforms each credential store targets).
 
 Please note: Since neither the maintainers nor GitHub do testing on BSD variants, we rely on contributors to support these platforms. Thanks for your help!
 

--- a/examples/ios.rs
+++ b/examples/ios.rs
@@ -40,10 +40,14 @@ fn test_empty_password_input() {
     let name = "test_empty_password_input".to_string();
     let entry = Entry::new(&name, &name).expect("Failed to create entry");
     let in_pass = "";
-    entry.set_password(in_pass).unwrap();
-    let out_pass = entry.get_password().unwrap();
+    entry
+        .set_password(in_pass)
+        .expect("Couldn't set empty password");
+    let out_pass = entry.get_password().expect("Couldn't get empty password");
     assert_eq!(in_pass, out_pass);
-    entry.delete_credential().unwrap();
+    entry
+        .delete_credential()
+        .expect("Couldn't delete credential with empty password");
     assert!(
         matches!(entry.get_password(), Err(Error::NoEntry)),
         "Able to read a deleted password"
@@ -91,19 +95,22 @@ fn test_update_password() {
 fn test_get_credential() {
     use keyring::ios::IosCredential;
     let name = "test_get_credential".to_string();
-    let entry = Entry::new(&name, &name).expect("Can't create entry");
+    let entry = Entry::new(&name, &name).expect("Can't create entry for get_credential");
     let credential: &IosCredential = entry
         .get_credential()
         .downcast_ref()
-        .expect("Not a mac credential");
+        .expect("Not an iOS credential");
     assert!(
         credential.get_credential().is_err(),
         "Platform credential shouldn't exist yet!"
     );
     entry
-        .set_password("test get password")
-        .expect("Can't set password for get_credential");
+        .set_password("test get password for get_credential")
+        .expect("Can't get password for get_credential");
     assert!(credential.get_credential().is_ok());
     entry.delete_credential().unwrap();
-    assert!(matches!(entry.get_password(), Err(Error::NoEntry)))
+    assert!(
+        matches!(entry.get_password(), Err(Error::NoEntry)),
+        "Platform credential exists after delete password"
+    )
 }


### PR DESCRIPTION
This fixes hwchen/keyring-rs#187 by releasing the fix contributed by @tmpfs.

It also fixes hwchen/keyring-rs#190 by using a "patch release" of the security-framework crate.

It also updates docs to fix hwchen/keyring-rs#189.