### PR TITLE
Release 3.0.2.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,22 @@ jobs:
         # run tests single-threaded to avoid dbus race conditions
         run: cargo test --features=${{ matrix.features }} -- --test-threads=1
 
+  ios_native:
+    runs-on: macos-latest
+
+    steps:
+      - name: Fetch head
+        uses: actions/checkout@v4
+
+      - name: Install rust stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-ios
+
+      - name: Build iOS library
+        run: cargo build --target aarch64-apple-ios --features=apple-native --example=iostest
+
   msrv_native:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "3.0.2-rc.1"
+version = "3.0.2"
 rust-version = "1.75"
 edition = "2021"
 exclude = [".github/"]
@@ -29,7 +29,7 @@ vendored = ["dbus-secret-service?/vendored", "openssl?/vendored"]
 openssl = { version = "0.10.55", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]  # see issue #190
-security-framework = { git = "https://github.com/brotskydotcom/rust-security-framework.git", branch = "fix-issue-206", optional = true }
+security-framework = { version = "2", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = { version = "4", optional = true }


### PR DESCRIPTION
This updates the workflows to make sure that we don't miss the iOS target in the CI runs.