### PR TITLE
Add support for credential-store attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## Version 3.3.0
+- Add support for credential-store attributes other than those used by this crate.  This allows the creation of credentials that are more compatible with 3rd-party clients, such as the OS-provided GUIs over credentials.
+- Make the textual descriptions of entries consistently follow the form `user@service` (or  `user@service:target` if a target was specified).
+
+## Version 3.2.1
+- Re-enable access to v1 credentials. The fixes of version 3.2 meant that legacy credentials with no target attribute couldn't be accessed.
+
+## Version 3.2.0
+- Improve secret-service handling of targets, so that searches on locked items distinguish items with different targets properly.
+
+## Version 3.1.0
+- enhance the CLI to allow empty user names and better info about `Ambiguous` credentials.
+
+## Version 3.0.5
+- updated docs and clean up dead code. No code changes.
+
+## Version 3.0.4
+- expose a cross-platform module alias via the `default` module.
+
+## Version 3.0.3
+- fix feature `linux-native`, which was causing compile errors.
+
 ## Version 3.0.2
 - add missing implementations for iOS `set_secret` and `get_secret`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "3.2.1"
+version = "3.3.0"
 rust-version = "1.75"
 edition = "2021"
 exclude = [".github/"]
@@ -64,6 +64,7 @@ path = "examples/cli.rs"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "wrap_help"] }
 rpassword = "7"
+rprompt = "2"
 rand = "0.8"
 doc-comment = "0.3"
 whoami = "1"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Thanks to the following for helping make this library better, whether through co
 - @russellbanks
 - @ryanavella
 - @samuela
+- @ShaunSHamilton
 - @stankec
 - @steveatinfincia
 - @Sytten

--- a/build-xplat-docs.sh
+++ b/build-xplat-docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cargo doc --no-deps --target aarch64-unknown-linux-musl $OPEN_DOCS
-cargo doc --no-deps --target aarch64-pc-windows-msvc $OPEN_DOCS
-cargo doc --no-deps --target aarch64-apple-darwin $OPEN_DOCS
-cargo doc --no-deps --target aarch64-apple-ios $OPEN_DOCS
+cargo doc --no-deps --features=linux-native --target aarch64-unknown-linux-musl $OPEN_DOCS
+cargo doc --no-deps --features=windows-native --target aarch64-pc-windows-msvc $OPEN_DOCS
+cargo doc --no-deps --features=apple-native --target aarch64-apple-darwin $OPEN_DOCS
+cargo doc --no-deps --features=apple-native --target aarch64-apple-ios $OPEN_DOCS

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,6 +1,7 @@
 extern crate keyring;
 
 use clap::Parser;
+use std::collections::HashMap;
 
 use keyring::{Entry, Error, Result};
 
@@ -21,40 +22,57 @@ fn main() {
     };
     match &args.command {
         Command::Set { .. } => {
-            let (secret, password) = args.get_password();
+            let (secret, password, attributes) = args.get_password_and_attributes();
+            if secret.is_none() && password.is_none() && attributes.is_none() {
+                eprintln!("You must provide either a password or attributes to the set command");
+                std::process::exit(1);
+            }
             if let Some(secret) = secret {
                 match entry.set_secret(&secret) {
-                    Ok(()) => args.success_message_for(Some(&secret), None),
+                    Ok(()) => args.success_message_for(Some(&secret), None, None),
                     Err(err) => args.error_message_for(err),
                 }
-            } else if let Some(password) = password {
+            }
+            if let Some(password) = password {
                 match entry.set_password(&password) {
-                    Ok(()) => args.success_message_for(None, Some(&password)),
+                    Ok(()) => args.success_message_for(None, Some(&password), None),
                     Err(err) => args.error_message_for(err),
                 }
-            } else {
-                if args.verbose {
-                    eprintln!("You must provide a password to the set command");
+            }
+            if let Some(attributes) = attributes {
+                let attrs: HashMap<&str, &str> = attributes
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value.as_str()))
+                    .collect();
+                match entry.update_attributes(&attrs) {
+                    Ok(()) => args.success_message_for(None, None, Some(attributes)),
+                    Err(err) => args.error_message_for(err),
                 }
-                std::process::exit(1)
             }
         }
         Command::Password => match entry.get_password() {
             Ok(password) => {
                 println!("{password}");
-                args.success_message_for(None, Some(&password));
+                args.success_message_for(None, Some(&password), None);
             }
             Err(err) => args.error_message_for(err),
         },
         Command::Secret => match entry.get_secret() {
             Ok(secret) => {
                 println!("{}", secret_string(&secret));
-                args.success_message_for(Some(&secret), None);
+                args.success_message_for(Some(&secret), None, None);
+            }
+            Err(err) => args.error_message_for(err),
+        },
+        Command::Attributes => match entry.get_attributes() {
+            Ok(attributes) => {
+                println!("{}", attributes_string(&attributes));
+                args.success_message_for(None, None, Some(attributes));
             }
             Err(err) => args.error_message_for(err),
         },
         Command::Delete => match entry.delete_credential() {
-            Ok(()) => args.success_message_for(None, None),
+            Ok(()) => args.success_message_for(None, None, None),
             Err(err) => args.error_message_for(err),
         },
     }
@@ -87,8 +105,15 @@ pub struct Cli {
 
 #[derive(Debug, Parser)]
 pub enum Command {
-    /// Set the password in the secure store
+    /// Set the password and, optionally, attributes in the secure store
     Set {
+        #[clap(short, long, action)]
+        /// The password is base64-encoded binary
+        binary: bool,
+
+        #[clap(short, long, value_parser, default_value = "")]
+        attributes: String,
+
         #[clap(value_parser)]
         /// The password to set into the secure store.
         /// If it's a valid base64 encoding (with padding),
@@ -105,7 +130,8 @@ pub enum Command {
     /// Retrieve the (binary) secret from the secure store
     /// and write it in base64 encoding to the standard output.
     Secret,
-    /// Delete the underlying credential from the secure store.
+    /// Retrieve attributes available in the secure store.
+    Attributes,
     Delete,
 }
 
@@ -146,6 +172,9 @@ impl Cli {
                     Command::Secret => {
                         eprintln!("Couldn't get secret for '{description}': {err}");
                     }
+                    Command::Attributes => {
+                        eprintln!("Couldn't get attributes for '{description}': {err}");
+                    }
                     Command::Delete => {
                         eprintln!("Couldn't delete credential for '{description}': {err}");
                     }
@@ -155,7 +184,12 @@ impl Cli {
         std::process::exit(1)
     }
 
-    fn success_message_for(&self, secret: Option<&[u8]>, password: Option<&str>) {
+    fn success_message_for(
+        &self,
+        secret: Option<&[u8]>,
+        password: Option<&str>,
+        attributes: Option<HashMap<String, String>>,
+    ) {
         if !self.verbose {
             return;
         }
@@ -169,6 +203,10 @@ impl Cli {
                     let secret = secret_string(secret);
                     eprintln!("Set secret for '{description}' to decode of '{secret}'");
                 }
+                if let Some(attributes) = attributes {
+                    eprintln!("Set attributes for '{description}' to:");
+                    eprint_attributes(attributes);
+                }
             }
             Command::Password => {
                 let pw = password.unwrap();
@@ -178,23 +216,48 @@ impl Cli {
                 let secret = secret_string(secret.unwrap());
                 eprintln!("Secret for '{description}' encodes as {secret}");
             }
+            Command::Attributes => {
+                let attributes = attributes.unwrap();
+                if attributes.is_empty() {
+                    eprintln!("No attributes found for '{description}'");
+                } else {
+                    eprintln!("Attributes for '{description}' are:");
+                    eprint_attributes(attributes);
+                }
+            }
             Command::Delete => {
                 eprintln!("Successfully deleted credential for '{description}'");
             }
         }
     }
 
-    fn get_password(&self) -> (Option<Vec<u8>>, Option<String>) {
-        match &self.command {
-            Command::Set { password: Some(pw) } => password_or_secret(pw),
-            Command::Set { password: None } => {
-                if let Ok(password) = rpassword::prompt_password("Password: ") {
-                    password_or_secret(&password)
-                } else {
-                    (None, None)
-                }
-            }
-            _ => (None, None),
+    fn get_password_and_attributes(
+        &self,
+    ) -> (
+        Option<Vec<u8>>,
+        Option<String>,
+        Option<HashMap<String, String>>,
+    ) {
+        if let Command::Set {
+            binary,
+            attributes,
+            password,
+        } = &self.command
+        {
+            let secret = if *binary {
+                Some(decode_secret(password))
+            } else {
+                None
+            };
+            let password = if !*binary {
+                Some(read_password(password))
+            } else {
+                None
+            };
+            let attributes = parse_attributes(attributes);
+            (secret, password, attributes)
+        } else {
+            panic!("Can't happen: asking for password and attributes on non-set command")
         }
     }
 }
@@ -205,11 +268,62 @@ fn secret_string(secret: &[u8]) -> String {
     BASE64_STANDARD.encode(secret)
 }
 
-fn password_or_secret(input: &str) -> (Option<Vec<u8>>, Option<String>) {
+fn eprint_attributes(attributes: HashMap<String, String>) {
+    for (key, value) in attributes {
+        println!("    {key}: {value}");
+    }
+}
+
+fn decode_secret(input: &Option<String>) -> Vec<u8> {
     use base64::prelude::*;
 
-    match BASE64_STANDARD.decode(input) {
-        Ok(secret) => (Some(secret), None),
-        Err(_) => (None, Some(input.to_string())),
+    let encoded = if let Some(input) = input {
+        input.clone()
+    } else {
+        rpassword::prompt_password("Base64 encoding: ").unwrap_or_else(|_| String::new())
+    };
+    if encoded.is_empty() {
+        return Vec::new();
     }
+    match BASE64_STANDARD.decode(encoded) {
+        Ok(secret) => secret,
+        Err(err) => {
+            eprintln!("Sorry, the provided secret data is not base64-encoded: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn read_password(input: &Option<String>) -> String {
+    let password = if let Some(input) = input {
+        input.clone()
+    } else {
+        rpassword::prompt_password("Password: ").unwrap_or_else(|_| String::new())
+    };
+    password
+}
+
+fn attributes_string(attributes: &HashMap<String, String>) -> String {
+    let strings = attributes
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>();
+    strings.join(",")
+}
+
+fn parse_attributes(input: &String) -> Option<HashMap<String, String>> {
+    if input.is_empty() {
+        return None;
+    }
+    let mut attributes = HashMap::new();
+    let parts = input.split(',');
+    for s in parts.into_iter() {
+        let parts: Vec<&str> = s.split("=").collect();
+        if parts.len() != 2 || parts[0].is_empty() {
+            eprintln!("Sorry, this part of the attributes string is not a key=val pair: {s}");
+            std::process::exit(1);
+        }
+        attributes.insert(parts[0].to_string(), parts[1].to_string());
+    }
+    Some(attributes)
 }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -1,6 +1,6 @@
 /*!
 
-# Platorm-independent secure storage model
+# Platform-independent secure storage model
 
 This module defines a plug and play model for platform-specific credential stores.
 The model comprises two traits: [CredentialBuilderApi] for the underlying store
@@ -44,17 +44,25 @@ pub trait CredentialApi {
     /// This will persist the secret in the underlying store.
     fn set_secret(&self, password: &[u8]) -> Result<()>;
 
-    /// Retrieve a password (a string) from the credential, if one has been set.
+    /// Retrieve the password (a string) from the underlying credential.
     ///
-    /// This has no effect on the underlying store.
+    /// This has no effect on the underlying store. If there is no credential
+    /// for this entry, a [NoEntry](crate::Error::NoEntry) error is returned.
     fn get_password(&self) -> Result<String>;
 
-    /// Retrieve a secret (a byte array) from the credential, if one has been set.
+    /// Retrieve a secret (a byte array) from the credential.
     ///
-    /// This has no effect on the underlying store.
+    /// This has no effect on the underlying store. If there is no credential
+    /// for this entry, a [NoEntry](crate::Error::NoEntry) error is returned.
     fn get_secret(&self) -> Result<Vec<u8>>;
 
-    /// Get the attributes on this credential from the underlying store.
+    /// Get the secure store attributes on this entry's credential.
+    ///
+    /// Each credential store may support reading and updating different
+    /// named attributes; see the documentation on each of the stores
+    /// for details. Note that the keyring itself uses some of these
+    /// attributes to map entries to their underlying credential; these
+    /// _controlled_ attributes are not available for reading or updating.
     ///
     /// We provide a default (no-op) implementation of this method
     /// for backward compatibility with stores that don't implement it.
@@ -65,7 +73,14 @@ pub trait CredentialApi {
         Ok(HashMap::new())
     }
 
-    /// Update attributes on the underlying credential store.
+    /// Update the secure store attributes on this entry's credential.
+    ///
+    /// Each credential store may support reading and updating different
+    /// named attributes; see the documentation on each of the stores
+    /// for details. The implementation will ignore any attribute names
+    /// that you supply that are not available for update. Because the
+    /// names used by the different stores tend to be distinct, you can
+    /// write cross-platform code that will work correctly on each platform.
     ///
     /// We provide a default no-op implementation of this method
     /// for backward compatibility with stores that don't implement it.

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -55,7 +55,7 @@ pub trait CredentialApi {
     fn get_secret(&self) -> Result<Vec<u8>>;
 
     /// Get the attributes on this credential from the underlying store.
-    /// 
+    ///
     /// We provide a default (no-op) implementation of this method
     /// for backward compatibility with stores that don't implement it.
     fn get_attributes(&self) -> Result<HashMap<String, String>> {

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -54,18 +54,27 @@ pub trait CredentialApi {
     /// This has no effect on the underlying store.
     fn get_secret(&self) -> Result<Vec<u8>>;
 
-    /// Get the attributes on this credential from the underlying credential store.
+    /// Get the attributes on this credential from the underlying store.
+    /// 
+    /// We provide a default (no-op) implementation of this method
+    /// for backward compatibility with stores that don't implement it.
+    fn get_attributes(&self) -> Result<HashMap<String, String>> {
+        // this should err in the same cases as get_secret, so first call that for effect
+        self.get_secret()?;
+        // if we got this far, return success with no attributes
+        Ok(HashMap::new())
+    }
+
+    /// Update attributes on the underlying credential store.
     ///
-    /// Almost all credential stores allow assigning named attributes to credentials.
-    /// Which attributes are allowed by which stores varies widely.
-    ///
-    /// The attributes returned by this call
-    /// include any that are used by this crate to identify
-    /// the `target`, `service`, and `user` of the credential.
-    /// The attributes used may not have those names; see the documentation
-    /// of each credential store for details of which attributes are used
-    /// and which additional attributes are returned by this call.
-    fn get_attributes(&self) -> Result<HashMap<String, String>>;
+    /// We provide a default no-op implementation of this method
+    /// for backward compatibility with stores that don't implement it.
+    fn update_attributes(&self, _: &HashMap<&str, &str>) -> Result<()> {
+        // this should err in the same cases as get_secret, so first call that for effect
+        self.get_secret()?;
+        // if we got this far, return success after setting no attributes
+        Ok(())
+    }
 
     /// Delete the underlying credential, if there is one.
     ///
@@ -126,38 +135,6 @@ pub trait CredentialBuilderApi {
     /// This typically has no effect on the content of the underlying store.
     /// A credential need not be persisted until its password is set.
     fn build(&self, target: Option<&str>, service: &str, user: &str) -> Result<Box<Credential>>;
-
-    /// Create a credential with additional platform-specific attributes.
-    ///
-    /// Almost all credential stores allow assigning named attributes to credentials.
-    /// In order to improve interoperability with 3rd-party software, you can
-    /// specify the desired values for attributes other than the ones that
-    /// are used by this crate to identify the `target`, `service`, and `user`
-    /// values of the credential.
-    ///
-    /// The attributes specified in this call are only applied when the credential
-    /// is first created in the underlying store, which is when the very first
-    /// secret value is assigned to the credential.  If a credential already exists
-    /// with the `target`, `service`, and `user` values specified in this call,
-    /// any additional attributes specified in it will be ignored.
-    ///
-    /// You can use the [CredentialApi::get_attributes] call to find out what
-    /// additional attributes are present on an existing credential. If you wish to
-    /// change those attributes, you will need to delete the existing credential,
-    /// then specify those attributes in this call, and the set a secret to create
-    /// the new credential with those attributes.
-    ///
-    /// Note that credential stores vary widely in what attributes they
-    /// allow and which are used by this crate.  The documentation of the
-    /// credential store implementations in this crate identify both
-    /// which attributes they use and which others can be set.
-    fn build_with_attributes(
-        &self,
-        target: Option<&str>,
-        service: &str,
-        user: &str,
-        attributes: HashMap<&str, &str>,
-    ) -> Result<Box<Credential>>;
 
     /// Return the underlying concrete object cast to [Any].
     ///

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -2,13 +2,18 @@
 
 # Linux kernel (keyutils) credential store
 
-Modern linux kernels have a built-in secure store, [keyutils](https://www.man7.org/linux/man-pages/man7/keyutils.7.html).
-This module (written primarily by [@landhb](https://github.com/landhb)) uses that secure store
-as the persistent back end for entries.
+Modern linux kernels have a built-in secure store,
+[keyutils](https://www.man7.org/linux/man-pages/man7/keyutils.7.html).
+This module (written primarily by [@landhb](https://github.com/landhb))
+uses that secure store as the persistent back end for entries.
 
 Entries in keyutils are identified by a string `description`.  If an entry is created with
 an explicit `target`, that value is used as the keyutils description.  Otherwise, the string
 `keyring-rs:user@service` is used (where user and service come from the entry creation call).
+
+There is no notion of attribute other than the description supported by keyutils,
+so the [get_attributes](Entry::get_attributes) and [update_attributes](Entry::update_attributes)
+calls are both no-ops for this credential store.
 
 # Persistence
 
@@ -401,6 +406,11 @@ mod tests {
     #[test]
     fn test_update() {
         crate::tests::test_update(entry_new);
+    }
+
+    #[test]
+    fn test_noop_get_update_attributes() {
+        crate::tests::test_noop_get_update_attributes(entry_new);
     }
 
     #[test]

--- a/src/keyutils.rs
+++ b/src/keyutils.rs
@@ -12,7 +12,8 @@ an explicit `target`, that value is used as the keyutils description.  Otherwise
 `keyring-rs:user@service` is used (where user and service come from the entry creation call).
 
 There is no notion of attribute other than the description supported by keyutils,
-so the [get_attributes](Entry::get_attributes) and [update_attributes](Entry::update_attributes)
+so the [get_attributes](crate::Entry::get_attributes)
+and [update_attributes](crate::Entry::update_attributes)
 calls are both no-ops for this credential store.
 
 # Persistence

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ mod tests {
         }
         entry
             .delete_credential()
-            .unwrap_or_else(|err| panic!("Can't delete password for attribute test: {err:?}"));
+            .unwrap_or_else(|err| panic!("Can't delete credential for attribute test: {err:?}"));
         assert!(
             matches!(entry.get_attributes(), Err(Error::NoEntry)),
             "Read deleted credential in attribute test",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,8 @@ then retrieving that as a password will return a
 [BadEncoding](Error::BadEncoding) error.
 The returned error will have the raw bytes attached,
 so you can access them, but you can also just fetch
-them directly using [get_secret](Entry::get_password) rather than
-[get_password](Entry::get_secret).
+them directly using [get_secret](Entry::get_secret) rather than
+[get_password](Entry::get_password).
 
 While this crate's code is thread-safe, the underlying credential
 stores may not handle access from different threads reliably.

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -213,7 +213,7 @@ impl CredentialBuilderApi for MacCredentialBuilder {
         service: &str,
         user: &str,
         _: HashMap<&str, &str>,
-    ) -> crate::Result<Box<Credential>> {
+    ) -> Result<Box<Credential>> {
         self.build(target, service, user)
     }
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -2,33 +2,32 @@
 
 # macOS Keychain credential store
 
-macOS credential stores are called keychains.
-The OS automatically creates three of them (or four if removable media is being used).
-Generic credentials on macOS can be identified by a large number of _key/value_ attributes;
-this module uses only the _account_ and _name_ attributes and ignores all others.
+All credentials on macOS are stored in secure stores called _keychains_.
+The OS automatically creates three of them (or four if removable media is being used),
+called _User_ (aka login), _Common_, _System_, and _Dynamic_.  The target
+attribute of an [Entry](crate::Entry) determines (case-insensitive) which keychain
+that entry's credential is created in or searched for.
+If the entry has no target, or the specified target doesn't name (case-insensitive)
+one of the four built-in keychains, the 'User' keychain is used.
 
-For a given service/user pair,
-this module targets a generic credential in the User (login) keychain
-whose _account_ is the user and whose _name_ is the service.
+For a given service/user pair, this module creates/searches for a credential
+in the target keychain whose _account_ attribute holds the user
+and whose _name_ attribute holds the service.
 Because of a quirk in the Mac keychain services API, neither the _account_
 nor the _name_ may be the empty string. (Empty strings are treated as
 wildcards when looking up credentials by attribute value.)
 
-In the _Keychain Access_ UI on Mac, generic credentials created by this module
+In the _Keychain Access_ UI on Mac, credentials created by this module
 show up in the passwords area (with their _where_ field equal to their _name_).
-_Note_ entries on Mac are also generic credentials and notes created by third-party
-applications can be accessed by this module
-if you know their _account_ value (not displayed by _Keychain Access_). But
-because the difference between a password and a note is platform-dependent,
-there's no way to _create_ a note in this module.
+What the Keychain Access lists under _Note_ entries on the Mac are
+also generic credentials, so existing _notes_ created by third-party
+applications can be accessed by this module if you know the value
+of their _account_ attribute (which is not displayed by _Keychain Access_).
 
-You can specify targeting a different keychain by passing the keychain's (case-insensitive)
-name as the target parameter to `Entry::new_with_target`.
-Any name other than one of the OS-supplied keychains (User, Common, System, and Dynamic)
-will be mapped to `User`.
+Credentials on macOS can have a large number of _key/value_ attributes,
+but this module controls the _account_ and _name_ attributes and
+ignores all the others. so clients can't use it to access or update any attributes.
  */
-use std::collections::HashMap;
-
 use security_framework::base::Error;
 use security_framework::os::macos::keychain::{SecKeychain, SecPreferencesDomain};
 use security_framework::os::macos::passwords::find_generic_password;
@@ -93,20 +92,6 @@ impl CredentialApi for MacCredential {
             find_generic_password(Some(&[get_keychain(self)?]), &self.service, &self.account)
                 .map_err(decode_error)?;
         Ok(password_bytes.to_vec())
-    }
-
-    /// Look up the attributes for this entry.
-    ///
-    /// Returns a [NoEntry](ErrorCode::NoEntry) error if there is no
-    /// matching credential in the store.
-    fn get_attributes(&self) -> Result<HashMap<String, String>> {
-        let (_, _) =
-            find_generic_password(Some(&[get_keychain(self)?]), &self.service, &self.account)
-                .map_err(decode_error)?;
-        let mut map: HashMap<String, String> = HashMap::new();
-        map.insert("account".to_string(), self.account.clone());
-        map.insert("service".to_string(), self.service.clone());
-        Ok(map)
     }
 
     /// Delete the underlying generic credential for this entry, if any.
@@ -201,20 +186,6 @@ impl CredentialBuilderApi for MacCredentialBuilder {
         Ok(Box::new(MacCredential::new_with_target(
             target, service, user,
         )?))
-    }
-
-    /// Build a [MacCredential] with additional attributes.
-    ///
-    /// Since this implementation doesn't know of any additional attributes,
-    /// the additional attributes are completely ignored.
-    fn build_with_attributes(
-        &self,
-        target: Option<&str>,
-        service: &str,
-        user: &str,
-        _: HashMap<&str, &str>,
-    ) -> Result<Box<Credential>> {
-        self.build(target, service, user)
     }
 
     /// Return the underlying builder object with an `Any` type so that it can
@@ -382,5 +353,10 @@ mod tests {
             .delete_credential()
             .expect("Couldn't delete after get_credential");
         assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
+    }
+
+    #[test]
+    fn test_get_update_attributes() {
+        crate::tests::test_noop_get_update_attributes(entry_new);
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -17,7 +17,7 @@ set_default_credential_builder(mock::default_credential_builder());
 You can then create entries as you usually do, and call their usual methods
 to set, get, and delete passwords.  There is no persistence other than
 in the entry itself, so getting a password before setting it will always result
-in a [NotFound](Error::NoEntry) error.
+in a [NoEntry](Error::NoEntry) error.
 
 If you want a method call on an entry to fail in a specific way, you can
 downcast the entry to a [MockCredential] and then call [set_error](MockCredential::set_error)
@@ -35,7 +35,6 @@ entry.set_password("test").expect("error has been cleared");
 ```
  */
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::sync::Mutex;
 
 use super::credential::{
@@ -144,13 +143,6 @@ impl CredentialApi for MockCredential {
         }
     }
 
-    /// Get the attributes on a mock credential.
-    ///
-    /// This always returns an empty map.
-    fn get_attributes(&self) -> Result<HashMap<String, String>> {
-        Ok(HashMap::new())
-    }
-
     /// Delete the password in a mock credential
     ///
     /// If there is an error, it will be returned and
@@ -227,19 +219,6 @@ impl CredentialBuilderApi for MockCredentialBuilder {
         Ok(Box::new(credential))
     }
 
-    /// Build a mock credential with additional attributes.
-    ///
-    /// Since mock credentials have no attributes, any passed attributes are ignored.
-    fn build_with_attributes(
-        &self,
-        target: Option<&str>,
-        service: &str,
-        user: &str,
-        _: HashMap<&str, &str>,
-    ) -> Result<Box<Credential>> {
-        self.build(target, service, user)
-    }
-
     /// Get an [Any][std::any::Any] reference to the mock credential builder.
     fn as_any(&self) -> &dyn std::any::Any {
         self
@@ -303,6 +282,11 @@ mod tests {
     #[test]
     fn test_update() {
         crate::tests::test_update(entry_new);
+    }
+
+    #[test]
+    fn test_get_update_attributes() {
+        crate::tests::test_noop_get_update_attributes(entry_new);
     }
 
     #[test]

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -3,13 +3,24 @@
 # secret-service credential store
 
 Items in the secret-service are identified by an arbitrary collection
-of attributes, and each has "label" for use in graphical editors.  This
-implementation uses the following attributes:
+of attributes.  This implementation controls the following attributes:
 
 - `target` (optional & taken from entry creation call, defaults to `default`)
 - `service` (required & taken from entry creation call)
-- `username` (required & taken from entry creation call)
-- `application` (optional & always set to `rust-keyring`)
+- `username` (required & taken from entry creation call's `user` parameter)
+
+In addition, when creating a new credential, this implementation assigns
+two additional attributes:
+
+- `application` (set to `rust-keyring-client`)
+- `label` (set to a string with the user, service, and keyring version at time of creation)
+
+Client code is allowed to retrieve and to set all attributes _except_ the
+three that are controlled by this implementation. (N.B. The `label` string
+is not actually an attribute; it's a required element in every item and is used
+by GUI tools as the name for the item. But this implementation treats the
+label as if it were any other non-controlled attribute, with the caveat that
+it will reject any attempt to set the label to an empty string.)
 
 Existing items are always searched for at the service level, which
 means all collections are searched. The search attributes used are
@@ -20,11 +31,11 @@ that were stored in the default collection, a fallback search is done
 for items in the default collection with no `target` attribute *if
 the original search for all three attributes returns no matches*.
 
-New items are always created with all three search attributes, and
-they are given a label that identifies the crate and version and
-attributes used in the entry. If a target other than `default` is
-specified for the entry, then a collection labeled with that target
-will be created (if necessary) to hold the new item.
+New items are created in the default collection,
+unless a target other than `default` is
+specified for the entry, in which case the item
+will be created in a collection (created if necessary)
+that is labeled with the specified target.
 
 Setting the password on an entry will always update the password on an
 existing item in preference to creating a new item.
@@ -179,6 +190,23 @@ impl CredentialApi for SsCredential {
         Ok(secrets[0].clone())
     }
 
+    /// Get attributes on a unique matching item, if it exists
+    ///
+    /// Same error conditions as [get_secret].
+    fn get_attributes(&self) -> Result<HashMap<String, String>> {
+        let attributes: Vec<HashMap<String, String>> =
+            self.map_matching_items(get_item_attributes, true)?;
+        Ok(attributes.into_iter().next().unwrap())
+    }
+
+    /// Update attributes on a unique matching item, if it exists
+    ///
+    /// Same error conditions as [get_secret].
+    fn update_attributes(&self, attributes: &HashMap<&str, &str>) -> Result<()> {
+        self.map_matching_items(|i| update_item_attributes(i, attributes), true)?;
+        Ok(())
+    }
+
     /// Deletes the unique matching item, if it exists.
     ///
     /// If there are no
@@ -227,7 +255,7 @@ impl SsCredential {
         Ok(Self {
             attributes,
             label: format!(
-                "keyring-rs v{} for target '{target}', service '{service}', user '{user}'",
+                "keyring v{}: {user}@{service}:{target}",
                 env!("CARGO_PKG_VERSION"),
             ),
             target: Some(target.to_string()),
@@ -496,10 +524,50 @@ pub fn get_item_password(item: &Item) -> Result<String> {
     decode_password(bytes)
 }
 
-//// Given an existing item, retrieve and decode its password.
+//// Given an existing item, retrieve its secret.
 pub fn get_item_secret(item: &Item) -> Result<Vec<u8>> {
     let secret = item.get_secret().map_err(decode_error)?;
     Ok(secret)
+}
+
+/// Given an existing item, retrieve its non-controlled attributes.
+pub fn get_item_attributes(item: &Item) -> Result<HashMap<String, String>> {
+    let mut attributes = item.get_attributes().map_err(decode_error)?;
+    attributes.remove("target");
+    attributes.remove("service");
+    attributes.remove("username");
+    attributes.insert("label".to_string(), item.get_label().map_err(decode_error)?);
+    Ok(attributes)
+}
+
+/// Given an existing item, retrieve its non-controlled attributes.
+pub fn update_item_attributes(item: &Item, attributes: &HashMap<&str, &str>) -> Result<()> {
+    let existing = item.get_attributes().map_err(decode_error)?;
+    let mut updated: HashMap<&str, &str> = HashMap::new();
+    for (k, v) in existing.iter() {
+        updated.insert(k, v);
+    }
+    for (k, v) in attributes.iter() {
+        if k.eq(&"target") || k.eq(&"service") || k.eq(&"username") {
+            continue;
+        }
+        if k.eq(&"label") {
+            if v.is_empty() {
+                return Err(ErrorCode::Invalid(
+                    "label".to_string(),
+                    "cannot be empty".to_string(),
+                ));
+            }
+            item.set_label(v).map_err(decode_error)?;
+            if updated.contains_key("label") {
+                updated.insert("label", v);
+            }
+        } else {
+            updated.insert(k, v);
+        }
+    }
+    item.set_attributes(updated).map_err(decode_error)?;
+    Ok(())
 }
 
 // Given an existing item, delete it.
@@ -542,6 +610,7 @@ fn wrap(err: Error) -> Box<dyn std::error::Error + Send + Sync> {
 mod tests {
     use crate::credential::CredentialPersistence;
     use crate::{tests::generate_random_string, Entry, Error};
+    use std::collections::HashMap;
 
     use super::{default_credential_builder, SsCredential};
 
@@ -627,6 +696,66 @@ mod tests {
             .delete_credential()
             .expect("Couldn't delete get-credential");
         assert!(matches!(entry.get_password(), Err(Error::NoEntry)));
+    }
+
+    #[test]
+    fn test_get_update_attributes() {
+        let name = generate_random_string();
+        let credential = SsCredential::new_with_target(None, &name, &name)
+            .expect("Can't create credential for attribute test");
+        let create_label = credential.label.clone();
+        let entry = Entry::new_with_credential(Box::new(credential));
+        assert!(
+            matches!(entry.get_attributes(), Err(Error::NoEntry)),
+            "Read missing credential in attribute test",
+        );
+        let mut in_map: HashMap<&str, &str> = HashMap::new();
+        in_map.insert("label", "test label value");
+        in_map.insert("test attribute name", "test attribute value");
+        in_map.insert("target", "ignored target value");
+        in_map.insert("service", "ignored service value");
+        in_map.insert("username", "ignored username value");
+        assert!(
+            matches!(entry.update_attributes(&in_map), Err(Error::NoEntry)),
+            "Updated missing credential in attribute test",
+        );
+        // create the credential and test again
+        entry
+            .set_password("test password for attributes")
+            .unwrap_or_else(|err| panic!("Can't set password for attribute test: {err:?}"));
+        let out_map = entry
+            .get_attributes()
+            .expect("Can't get attributes after create");
+        assert_eq!(out_map["label"], create_label);
+        assert_eq!(out_map["application"], "rust-keyring");
+        assert!(!out_map.contains_key("target"));
+        assert!(!out_map.contains_key("service"));
+        assert!(!out_map.contains_key("username"));
+        assert!(
+            matches!(entry.update_attributes(&in_map), Ok(())),
+            "Couldn't update attributes in attribute test",
+        );
+        let after_map = entry
+            .get_attributes()
+            .expect("Can't get attributes after update");
+        assert_eq!(after_map["label"], in_map["label"]);
+        assert_eq!(
+            after_map["test attribute name"],
+            in_map["test attribute name"]
+        );
+        assert_eq!(out_map["application"], "rust-keyring");
+        in_map.insert("label", "");
+        assert!(
+            matches!(entry.update_attributes(&in_map), Err(Error::Invalid(_, _))),
+            "Was able to set empty label in attribute test",
+        );
+        entry
+            .delete_credential()
+            .unwrap_or_else(|err| panic!("Can't delete credential for attribute test: {err:?}"));
+        assert!(
+            matches!(entry.get_attributes(), Err(Error::NoEntry)),
+            "Read deleted credential in attribute test",
+        );
     }
 
     #[test]

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -13,7 +13,7 @@ In addition, when creating a new credential, this implementation assigns
 two additional attributes:
 
 - `application` (set to `rust-keyring-client`)
-- `label` (set to a string with the user, service, and keyring version at time of creation)
+- `label` (set to a string with the user, service, target, and keyring version at time of creation)
 
 Client code is allowed to retrieve and to set all attributes _except_ the
 three that are controlled by this implementation. (N.B. The `label` string

--- a/src/secret_service.rs
+++ b/src/secret_service.rs
@@ -255,7 +255,7 @@ impl SsCredential {
         Ok(Self {
             attributes,
             label: format!(
-                "keyring v{}: {user}@{service}:{target}",
+                "{user}@{service}:{target} (keyring v{})",
                 env!("CARGO_PKG_VERSION"),
             ),
             target: Some(target.to_string()),

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -339,7 +339,6 @@ impl WinCredential {
         user: &str,
     ) -> Result<WinCredential> {
         const VERSION: &str = env!("CARGO_PKG_VERSION");
-        let metadata = format!("keyring-rs v{VERSION} for service '{service}', user '{user}'");
         let credential = if let Some(target) = target {
             // if target.is_empty() {
             //     return Err(ErrorCode::Invalid(
@@ -354,7 +353,7 @@ impl WinCredential {
                 username: user.to_string(),
                 target_name: target.to_string(),
                 target_alias: String::new(),
-                comment: metadata,
+                comment: format!("{user}@{service}:{target} (keyring v{VERSION})"),
             }
         } else {
             Self {
@@ -369,7 +368,7 @@ impl WinCredential {
                 username: user.to_string(),
                 target_name: format!("{user}.{service}"),
                 target_alias: String::new(),
-                comment: metadata,
+                comment: format!("{user}@{service}:{user}.{service} (keyring v{VERSION})"),
             }
         };
         credential.validate_attributes(None, None)?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -21,6 +21,11 @@ So if you have a custom algorithm you want to use for computing the Windows targ
 you can specify the target name directly.  (You still need to provide a service and username,
 because they are used in the credential's metadata.)
 
+The [get_attributes](Entry::get_attributes)
+call will return the values in the `username`, `comment`, and `target_alias` fields
+(using those strings as the attribute names), and the [update_attributes](Entry::update_attributes)
+call allows setting those fields.
+
 ## Caveat
 
 Reads and writes of the same entry from multiple threads
@@ -31,6 +36,7 @@ different threads produces different results on different runs.
 */
 
 use byteorder::{ByteOrder, LittleEndian};
+use std::collections::HashMap;
 use std::iter::once;
 use std::mem::MaybeUninit;
 use std::str;
@@ -89,47 +95,7 @@ impl CredentialApi for WinCredential {
     /// there is no chance of ambiguity.
     fn set_secret(&self, secret: &[u8]) -> Result<()> {
         self.validate_attributes(Some(secret), None)?;
-        let mut username = to_wstr(&self.username);
-        let mut target_name = to_wstr(&self.target_name);
-        let mut target_alias = to_wstr(&self.target_alias);
-        let mut comment = to_wstr(&self.comment);
-        // Password strings are converted to UTF-16, because that's the native
-        // charset for Windows strings.  This allows editing of the password in
-        // the Windows native UI.  But the storage for the credential is actually
-        // a little-endian blob, because passwords can contain anything.
-        let mut blob = secret.to_vec();
-        let blob_len = blob.len() as u32;
-        let flags = CRED_FLAGS::default();
-        let cred_type = CRED_TYPE_GENERIC;
-        let persist = CRED_PERSIST_ENTERPRISE;
-        // Ignored by CredWriteW
-        let last_written = FILETIME {
-            dwLowDateTime: 0,
-            dwHighDateTime: 0,
-        };
-        let attribute_count = 0;
-        let attributes: *mut CREDENTIAL_ATTRIBUTEW = std::ptr::null_mut();
-        let mut credential = CREDENTIALW {
-            Flags: flags,
-            Type: cred_type,
-            TargetName: target_name.as_mut_ptr(),
-            Comment: comment.as_mut_ptr(),
-            LastWritten: last_written,
-            CredentialBlobSize: blob_len,
-            CredentialBlob: blob.as_mut_ptr(),
-            Persist: persist,
-            AttributeCount: attribute_count,
-            Attributes: attributes,
-            TargetAlias: target_alias.as_mut_ptr(),
-            UserName: username.as_mut_ptr(),
-        };
-        // raw pointer to credential, is coerced from &mut
-        let p_credential: *const CREDENTIALW = &mut credential;
-        // Call windows API
-        match unsafe { CredWriteW(p_credential, 0) } {
-            0 => Err(decode_error()),
-            _ => Ok(()),
-        }
+        self.save_credential(secret)
     }
 
     /// Look up the password for this entry, if any.
@@ -146,6 +112,39 @@ impl CredentialApi for WinCredential {
     /// credential in the store.
     fn get_secret(&self) -> Result<Vec<u8>> {
         self.extract_from_platform(extract_secret)
+    }
+
+    /// Get the attributes from the credential for this entry, if it exists.
+    ///
+    /// Returns a [NoEntry](ErrorCode::NoEntry) error if there is no
+    /// credential in the store.
+    fn get_attributes(&self) -> Result<HashMap<String, String>> {
+        let cred = self.extract_from_platform(Self::extract_credential)?;
+        let mut attributes: HashMap<String, String> = HashMap::new();
+        attributes.insert("comment".to_string(), cred.comment.clone());
+        attributes.insert("target_alias".to_string(), cred.target_alias.clone());
+        attributes.insert("username".to_string(), cred.username.clone());
+        Ok(attributes)
+    }
+
+    /// Update the attributes on the credential for this entry, if it exists.
+    ///
+    /// Returns a [NoEntry](ErrorCode::NoEntry) error if there is no
+    /// credential in the store.
+    fn update_attributes(&self, attributes: &HashMap<&str, &str>) -> Result<()> {
+        let secret = self.extract_from_platform(extract_secret)?;
+        let mut cred = self.extract_from_platform(Self::extract_credential)?;
+        if let Some(comment) = attributes.get(&"comment") {
+            cred.comment = comment.to_string();
+        }
+        if let Some(target_alias) = attributes.get(&"target_alias") {
+            cred.target_alias = target_alias.to_string();
+        }
+        if let Some(username) = attributes.get(&"username") {
+            cred.username = username.to_string();
+        }
+        cred.validate_attributes(Some(&secret), None)?;
+        cred.save_credential(&secret)
     }
 
     /// Delete the underlying generic credential for this entry, if any.
@@ -225,6 +224,49 @@ impl WinCredential {
             }
         }
         Ok(())
+    }
+
+    /// Write this credential into the underlying store as a Generic credential
+    ///
+    /// You must always have validated attributes before you call this!
+    fn save_credential(&self, secret: &[u8]) -> Result<()> {
+        let mut username = to_wstr(&self.username);
+        let mut target_name = to_wstr(&self.target_name);
+        let mut target_alias = to_wstr(&self.target_alias);
+        let mut comment = to_wstr(&self.comment);
+        let mut blob = secret.to_vec();
+        let blob_len = blob.len() as u32;
+        let flags = CRED_FLAGS::default();
+        let cred_type = CRED_TYPE_GENERIC;
+        let persist = CRED_PERSIST_ENTERPRISE;
+        // Ignored by CredWriteW
+        let last_written = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let attribute_count = 0;
+        let attributes: *mut CREDENTIAL_ATTRIBUTEW = std::ptr::null_mut();
+        let mut credential = CREDENTIALW {
+            Flags: flags,
+            Type: cred_type,
+            TargetName: target_name.as_mut_ptr(),
+            Comment: comment.as_mut_ptr(),
+            LastWritten: last_written,
+            CredentialBlobSize: blob_len,
+            CredentialBlob: blob.as_mut_ptr(),
+            Persist: persist,
+            AttributeCount: attribute_count,
+            Attributes: attributes,
+            TargetAlias: target_alias.as_mut_ptr(),
+            UserName: username.as_mut_ptr(),
+        };
+        // raw pointer to credential, is coerced from &mut
+        let p_credential: *const CREDENTIALW = &mut credential;
+        // Call windows API
+        match unsafe { CredWriteW(p_credential, 0) } {
+            0 => Err(decode_error()),
+            _ => Ok(()),
+        }
     }
 
     /// Construct a credential from this credential's underlying Generic credential.
@@ -622,6 +664,57 @@ mod tests {
     #[test]
     fn test_update() {
         crate::tests::test_update(entry_new);
+    }
+
+    #[test]
+    fn test_get_update_attributes() {
+        let name = generate_random_string();
+        let cred = WinCredential::new_with_target(None, &name, &name)
+            .expect("Can't create credential for attribute test");
+        let entry = Entry::new_with_credential(Box::new(cred.clone()));
+        assert!(
+            matches!(entry.get_attributes(), Err(ErrorCode::NoEntry)),
+            "Read missing credential in attribute test",
+        );
+        let mut in_map: HashMap<&str, &str> = HashMap::new();
+        in_map.insert("label", "ignored label value");
+        in_map.insert("attribute name", "ignored attribute value");
+        in_map.insert("target_alias", "target alias value");
+        in_map.insert("comment", "comment value");
+        in_map.insert("username", "username value");
+        assert!(
+            matches!(entry.update_attributes(&in_map), Err(ErrorCode::NoEntry)),
+            "Updated missing credential in attribute test",
+        );
+        // create the credential and test again
+        entry
+            .set_password("test password for attributes")
+            .unwrap_or_else(|err| panic!("Can't set password for attribute test: {err:?}"));
+        let out_map = entry
+            .get_attributes()
+            .expect("Can't get attributes after create");
+        assert_eq!(out_map["target_alias"], cred.target_alias);
+        assert_eq!(out_map["comment"], cred.comment);
+        assert_eq!(out_map["username"], cred.username);
+        assert!(
+            matches!(entry.update_attributes(&in_map), Ok(())),
+            "Couldn't update attributes in attribute test",
+        );
+        let after_map = entry
+            .get_attributes()
+            .expect("Can't get attributes after update");
+        assert_eq!(after_map["target_alias"], in_map["target_alias"]);
+        assert_eq!(after_map["comment"], in_map["comment"]);
+        assert_eq!(after_map["username"], in_map["username"]);
+        assert!(!after_map.contains_key("label"));
+        assert!(!after_map.contains_key("attribute name"));
+        entry
+            .delete_credential()
+            .unwrap_or_else(|err| panic!("Can't delete credential for attribute test: {err:?}"));
+        assert!(
+            matches!(entry.get_attributes(), Err(ErrorCode::NoEntry)),
+            "Read deleted credential in attribute test",
+        );
     }
 
     #[test]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -21,9 +21,10 @@ So if you have a custom algorithm you want to use for computing the Windows targ
 you can specify the target name directly.  (You still need to provide a service and username,
 because they are used in the credential's metadata.)
 
-The [get_attributes](Entry::get_attributes)
+The [get_attributes](crate::Entry::get_attributes)
 call will return the values in the `username`, `comment`, and `target_alias` fields
-(using those strings as the attribute names), and the [update_attributes](Entry::update_attributes)
+(using those strings as the attribute names),
+and the [update_attributes](crate::Entry::update_attributes)
 call allows setting those fields.
 
 ## Caveat


### PR DESCRIPTION
- Add support for credential-store attributes other than those used by this crate.  This allows the creation of credentials that are more compatible with 3rd-party clients, such as the OS-provided GUIs over credentials.
- Make the textual descriptions of entries consistently follow the form `user@service` (or  `user@service:target` if a target was specified).

Fixes #208.
