### PR TITLE
Revert security framework to v2 on iOS.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,11 @@ vendored = ["dbus-secret-service?/vendored", "openssl?/vendored"]
 log = "0.4.22"
 openssl = { version = "0.10.55", optional = true }
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]  # see issue #190
+[target.'cfg(target_os = "macos")'.dependencies]  # see issue #190
 security-framework = { version = "3", optional = true }
+
+[target.'cfg(target_os = "ios")'.dependencies]  # see issue #190
+security-framework = { version = "2", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = { version = "4", optional = true }


### PR DESCRIPTION
Turns out security framework v3 doesn't link on iOS.

 Fixes hwchen/keyring-rs#224.