### PR TITLE
Switch to using fastrand for testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Version 3.6.2
+- Have docs.rs build docs for all modules on all platforms (thanks to @unkcpz - see #235).
+- Switch to `fastrand` for tests (see #237).
+
+## Version 3.6.1
+- Updated dependencies; no code changes.
+
 ## Version 3.6.0
 - Add combination keystore of keyutils and secret service (thanks to @soywod).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "keyring", "cross-platform"]
 license = "MIT OR Apache-2.0"
 name = "keyring"
 repository = "https://github.com/hwchen/keyring-rs.git"
-version = "3.6.1"
+version = "3.6.2"
 rust-version = "1.75"
 edition = "2021"
 exclude = [".github/"]
@@ -71,7 +71,7 @@ base64 = "0.22"
 clap = { version = "4", features = ["derive", "wrap_help"] }
 doc-comment = "0.3"
 env_logger = "0.11.5"
-rand = "0.8"
+fastrand = "2"
 rpassword = "7"
 rprompt = "2"
 whoami = "1.5"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,4 @@
-use common::{generate_random_string, init_logger};
+use common::{generate_random_bytes_of_len, generate_random_string, init_logger};
 use keyring::{Entry, Error};
 
 mod common;
@@ -90,15 +90,16 @@ fn test_round_trip_non_ascii_password() {
 fn test_round_trip_random_secret() {
     init_logger();
 
-    use rand::{rngs::OsRng, Rng};
     let name = generate_random_string();
     let entry = Entry::new(&name, &name).expect("Can't create entry");
-    let mut secret: [u8; 16] = [0; 16];
-    OsRng.fill(&mut secret);
-    entry.set_secret(&secret).expect("Can't set random secret");
+    let secret = generate_random_bytes_of_len(24);
+    entry
+        .set_secret(secret.as_slice())
+        .expect("Can't set random secret");
     let stored_secret = entry.get_secret().expect("Can't get random secret");
     assert_eq!(
-        &stored_secret, &secret,
+        &stored_secret,
+        secret.as_slice(),
         "Retrieved and set random secrets don't match"
     );
     entry

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,22 +1,31 @@
+#![allow(dead_code)] // not all of these utilities are used by all tests
+
 /// When tests fail, they leave keys behind, and those keys
 /// have to be cleaned up before the tests can be run again
 /// in order to avoid bad results.  So it's a lot easier just
 /// to have tests use a random string for key names to avoid
 /// the conflicts, and then do any needed cleanup once everything
 /// is working correctly.  So tests make keys with these functions.
+/// When tests fail, they leave keys behind, and those keys
+/// have to be cleaned up before the tests can be run again
+/// in order to avoid bad results.  So it's a lot easier just
+/// to have tests use a random string for key names to avoid
+/// the conflicts, and then do any needed cleanup once everything
+/// is working correctly.  So we export this function for tests to use.
 pub fn generate_random_string_of_len(len: usize) -> String {
-    // from the Rust Cookbook:
-    // https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html
-    use rand::{distributions::Alphanumeric, thread_rng, Rng};
-    thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(len)
-        .map(char::from)
-        .collect()
+    use fastrand;
+    use std::iter::repeat_with;
+    repeat_with(fastrand::alphanumeric).take(len).collect()
 }
 
 pub fn generate_random_string() -> String {
     generate_random_string_of_len(30)
+}
+
+pub fn generate_random_bytes_of_len(len: usize) -> Vec<u8> {
+    use fastrand;
+    use std::iter::repeat_with;
+    repeat_with(|| fastrand::u8(..)).take(len).collect()
 }
 
 pub fn init_logger() {


### PR DESCRIPTION
This removes the use of the rand crate.

Fixes hwchen/keyring-rs#236.